### PR TITLE
Add transaction history table and skeleton loading components

### DIFF
--- a/Frontend/app/components/Navbar.tsx
+++ b/Frontend/app/components/Navbar.tsx
@@ -13,6 +13,9 @@ export default function Navbar() {
         GateDelay
       </Link>
       <div className="flex items-center gap-4">
+        <Link href="/transactions" className="text-sm" style={{ color: "var(--muted)" }}>
+          History
+        </Link>
         <Link href="/settings" className="text-sm" style={{ color: "var(--muted)" }}>
           Settings
         </Link>

--- a/Frontend/app/components/transactions/TransactionHistory.tsx
+++ b/Frontend/app/components/transactions/TransactionHistory.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getPaginationRowModel,
+  getFilteredRowModel,
+  flexRender,
+  createColumnHelper,
+  type SortingState,
+  type ColumnFiltersState,
+} from "@tanstack/react-table";
+import { format, isWithinInterval, parseISO } from "date-fns";
+
+export type TransactionType = "buy" | "sell" | "redeem" | "deposit" | "withdraw";
+export type TransactionStatus = "confirmed" | "pending" | "failed";
+
+export interface Transaction {
+  id: string;
+  date: string; // ISO string
+  type: TransactionType;
+  market: string;
+  amount: number;
+  status: TransactionStatus;
+  txHash: string;
+}
+
+// ── mock data (replace with real API fetch) ──────────────────────────────────
+const MOCK_TRANSACTIONS: Transaction[] = Array.from({ length: 47 }, (_, i) => {
+  const types: TransactionType[] = ["buy", "sell", "redeem", "deposit", "withdraw"];
+  const statuses: TransactionStatus[] = ["confirmed", "pending", "failed"];
+  const markets = ["AA123 on-time?", "UA456 delay >30m?", "DL789 cancelled?", "SW101 on-time?"];
+  const d = new Date(2026, 3, 23 - (i % 30));
+  return {
+    id: `tx-${i + 1}`,
+    date: d.toISOString(),
+    type: types[i % types.length],
+    market: markets[i % markets.length],
+    amount: parseFloat((Math.random() * 500 + 5).toFixed(2)),
+    status: statuses[i % statuses.length],
+    txHash: `0x${Math.random().toString(16).slice(2, 10)}…`,
+  };
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+const STATUS_STYLES: Record<TransactionStatus, { bg: string; color: string }> = {
+  confirmed: { bg: "#22c55e22", color: "#22c55e" },
+  pending:   { bg: "#f59e0b22", color: "#f59e0b" },
+  failed:    { bg: "#ef444422", color: "#ef4444" },
+};
+
+const TYPE_LABELS: Record<TransactionType, string> = {
+  buy: "Buy", sell: "Sell", redeem: "Redeem", deposit: "Deposit", withdraw: "Withdraw",
+};
+
+function exportCSV(rows: Transaction[]) {
+  const header = ["Date", "Type", "Market", "Amount (USDC)", "Status", "Tx Hash"];
+  const lines = rows.map((r) => [
+    format(parseISO(r.date), "yyyy-MM-dd HH:mm"),
+    r.type,
+    `"${r.market}"`,
+    r.amount.toFixed(2),
+    r.status,
+    r.txHash,
+  ]);
+  const csv = [header, ...lines].map((l) => l.join(",")).join("\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `transactions-${format(new Date(), "yyyy-MM-dd")}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+const columnHelper = createColumnHelper<Transaction>();
+
+const COLUMNS = [
+  columnHelper.accessor("date", {
+    header: "Date",
+    cell: (info) => format(parseISO(info.getValue()), "MMM d, yyyy HH:mm"),
+    sortingFn: "datetime",
+  }),
+  columnHelper.accessor("type", {
+    header: "Type",
+    cell: (info) => (
+      <span className="capitalize text-xs font-medium px-2 py-0.5 rounded-full"
+        style={{ background: "var(--border)", color: "var(--foreground)" }}>
+        {TYPE_LABELS[info.getValue()]}
+      </span>
+    ),
+  }),
+  columnHelper.accessor("market", { header: "Market" }),
+  columnHelper.accessor("amount", {
+    header: "Amount (USDC)",
+    cell: (info) => `$${info.getValue().toFixed(2)}`,
+  }),
+  columnHelper.accessor("status", {
+    header: "Status",
+    cell: (info) => {
+      const s = info.getValue();
+      const style = STATUS_STYLES[s];
+      return (
+        <span className="text-xs font-semibold px-2 py-0.5 rounded-full capitalize"
+          style={{ background: style.bg, color: style.color }}>
+          {s}
+        </span>
+      );
+    },
+  }),
+  columnHelper.accessor("txHash", {
+    header: "Tx Hash",
+    enableSorting: false,
+    cell: (info) => (
+      <span className="font-mono text-xs" style={{ color: "var(--muted)" }}>
+        {info.getValue()}
+      </span>
+    ),
+  }),
+];
+
+// ── component ─────────────────────────────────────────────────────────────────
+interface Props {
+  /** Pass real data from an API; falls back to mock data */
+  data?: Transaction[];
+}
+
+export default function TransactionHistory({ data = MOCK_TRANSACTIONS }: Props) {
+  const [sorting, setSorting] = useState<SortingState>([{ id: "date", desc: true }]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  // Apply date-range + type filters before handing to the table
+  const filtered = useMemo(() => {
+    return data.filter((row) => {
+      if (typeFilter !== "all" && row.type !== typeFilter) return false;
+      if (dateFrom || dateTo) {
+        const d = parseISO(row.date);
+        const from = dateFrom ? parseISO(dateFrom) : new Date(0);
+        const to = dateTo ? parseISO(dateTo) : new Date(8640000000000000);
+        if (!isWithinInterval(d, { start: from, end: to })) return false;
+      }
+      return true;
+    });
+  }, [data, typeFilter, dateFrom, dateTo]);
+
+  const table = useReactTable({
+    data: filtered,
+    columns: COLUMNS,
+    state: { sorting, columnFilters },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: 10 } },
+  });
+
+  const handleExport = useCallback(() => {
+    const rows = table.getFilteredRowModel().rows.map((r) => r.original);
+    exportCSV(rows);
+  }, [table]);
+
+  const { pageIndex, pageSize } = table.getState().pagination;
+  const pageCount = table.getPageCount();
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-wrap items-end gap-3">
+        {/* Type filter */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs" style={{ color: "var(--muted)" }}>Type</label>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="rounded-lg px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+          >
+            <option value="all">All types</option>
+            {(Object.keys(TYPE_LABELS) as TransactionType[]).map((t) => (
+              <option key={t} value={t}>{TYPE_LABELS[t]}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Date from */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs" style={{ color: "var(--muted)" }}>From</label>
+          <input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+            className="rounded-lg px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+          />
+        </div>
+
+        {/* Date to */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs" style={{ color: "var(--muted)" }}>To</label>
+          <input
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+            className="rounded-lg px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+          />
+        </div>
+
+        <button
+          onClick={handleExport}
+          className="ml-auto rounded-lg px-4 py-2 text-sm font-medium transition-opacity hover:opacity-80"
+          style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+        >
+          ↓ Export CSV
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl" style={{ border: "1px solid var(--border)" }}>
+        <table className="w-full text-sm">
+          <thead>
+            {table.getHeaderGroups().map((hg) => (
+              <tr key={hg.id} style={{ borderBottom: "1px solid var(--border)", background: "var(--card)" }}>
+                {hg.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    className="px-4 py-3 text-left text-xs font-semibold select-none"
+                    style={{
+                      color: "var(--muted)",
+                      cursor: header.column.getCanSort() ? "pointer" : "default",
+                      whiteSpace: "nowrap",
+                    }}
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.column.getCanSort() && (
+                      <span className="ml-1 opacity-60">
+                        {{ asc: "↑", desc: "↓" }[header.column.getIsSorted() as string] ?? "↕"}
+                      </span>
+                    )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.length === 0 ? (
+              <tr>
+                <td colSpan={COLUMNS.length} className="px-4 py-10 text-center text-sm" style={{ color: "var(--muted)" }}>
+                  No transactions found.
+                </td>
+              </tr>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <tr
+                  key={row.id}
+                  style={{ borderTop: "1px solid var(--border)" }}
+                  className="transition-colors hover:bg-(--card)"
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-4 py-3 whitespace-nowrap" style={{ color: "var(--foreground)" }}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between gap-2 flex-wrap text-sm">
+        <span style={{ color: "var(--muted)" }}>
+          {filtered.length} transaction{filtered.length !== 1 ? "s" : ""}
+          {" · "}page {pageIndex + 1} of {pageCount || 1}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+            className="rounded-lg px-3 py-1.5 text-xs font-medium disabled:opacity-40 transition-opacity hover:opacity-80"
+            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+          >
+            «
+          </button>
+          <button
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            className="rounded-lg px-3 py-1.5 text-xs font-medium disabled:opacity-40 transition-opacity hover:opacity-80"
+            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+          >
+            ‹ Prev
+          </button>
+          <button
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            className="rounded-lg px-3 py-1.5 text-xs font-medium disabled:opacity-40 transition-opacity hover:opacity-80"
+            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+          >
+            Next ›
+          </button>
+          <button
+            onClick={() => table.setPageIndex(pageCount - 1)}
+            disabled={!table.getCanNextPage()}
+            className="rounded-lg px-3 py-1.5 text-xs font-medium disabled:opacity-40 transition-opacity hover:opacity-80"
+            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+          >
+            »
+          </button>
+          <select
+            value={pageSize}
+            onChange={(e) => table.setPageSize(Number(e.target.value))}
+            className="rounded-lg px-2 py-1.5 text-xs outline-none"
+            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+          >
+            {[10, 20, 50].map((s) => (
+              <option key={s} value={s}>Show {s}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/app/components/ui/Skeleton.tsx
+++ b/Frontend/app/components/ui/Skeleton.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface SkeletonProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/** Base animated skeleton block */
+export function Skeleton({ className = "", style }: SkeletonProps) {
+  return (
+    <motion.div
+      animate={{ backgroundPosition: ["200% 0", "-200% 0"] }}
+      transition={{ duration: 1.6, repeat: Infinity, ease: "linear" }}
+      className={`rounded-md ${className}`}
+      style={{
+        background:
+          "linear-gradient(90deg, var(--card) 25%, var(--border) 50%, var(--card) 75%)",
+        backgroundSize: "400% 100%",
+        ...style,
+      }}
+    />
+  );
+}
+
+/** Skeleton for a single market card row */
+export function MarketCardSkeleton() {
+  return (
+    <div
+      className="flex items-center justify-between rounded-xl px-5 py-4"
+      style={{ border: "1px solid var(--border)" }}
+    >
+      <div className="space-y-2 flex-1 mr-8">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-3 w-1/4" />
+      </div>
+      <div className="space-y-2 text-right">
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-3 w-12" />
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton for a list of market cards */
+export function MarketListSkeleton({ count = 3 }: { count?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: count }).map((_, i) => (
+        <MarketCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+/** Skeleton for a stats grid (4 cards) */
+export function StatsSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className="rounded-xl p-4 space-y-2"
+          style={{ background: "var(--card)", border: "1px solid var(--border)" }}
+        >
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-6 w-20" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Skeleton for a chart area */
+export function ChartSkeleton({ height = 192 }: { height?: number }) {
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ border: "1px solid var(--border)", height }}
+    >
+      <Skeleton className="h-full w-full rounded-xl" />
+    </div>
+  );
+}
+
+/** Skeleton for a transaction table */
+export function TransactionTableSkeleton({ rows = 5 }: { rows?: number }) {
+  const cols = [140, 80, 160, 100, 90, 100]; // approximate col widths
+  return (
+    <div className="space-y-4">
+      {/* Filter bar skeleton */}
+      <div className="flex gap-3 flex-wrap">
+        <Skeleton className="h-9 w-32 rounded-lg" />
+        <Skeleton className="h-9 w-36 rounded-lg" />
+        <Skeleton className="h-9 w-36 rounded-lg" />
+        <Skeleton className="h-9 w-28 rounded-lg ml-auto" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="rounded-xl overflow-hidden" style={{ border: "1px solid var(--border)" }}>
+        {/* Header */}
+        <div
+          className="flex gap-4 px-4 py-3"
+          style={{ background: "var(--card)", borderBottom: "1px solid var(--border)" }}
+        >
+          {cols.map((w, i) => (
+            <Skeleton key={i} className="h-3 rounded" style={{ width: w * 0.6 }} />
+          ))}
+        </div>
+        {/* Rows */}
+        {Array.from({ length: rows }).map((_, ri) => (
+          <div
+            key={ri}
+            className="flex gap-4 px-4 py-3"
+            style={{ borderTop: "1px solid var(--border)" }}
+          >
+            {cols.map((w, ci) => (
+              <Skeleton key={ci} className="h-4 rounded" style={{ width: w }} />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Pagination skeleton */}
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-40 rounded" />
+        <div className="flex gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-16 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/app/markets/[id]/page.tsx
+++ b/Frontend/app/markets/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useState } from "react";
+import { useState, Suspense } from "react";
+import { StatsSkeleton, ChartSkeleton } from "../../components/ui/Skeleton";
 
 // Mock data — replace with real contract/API calls
 const MOCK_MARKET = {
@@ -55,6 +56,7 @@ export default function MarketDetailPage({ params }: { params: { id: string } })
       </div>
 
       {/* Stats */}
+      <Suspense fallback={<StatsSkeleton count={4} />}>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {[
           { label: "YES Price", value: `${(market.yesPrice * 100).toFixed(0)}¢` },
@@ -72,14 +74,17 @@ export default function MarketDetailPage({ params }: { params: { id: string } })
           </div>
         ))}
       </div>
+      </Suspense>
 
       {/* Chart placeholder */}
+      <Suspense fallback={<ChartSkeleton height={192} />}>
       <div
         className="rounded-xl p-6 flex items-center justify-center h-48"
         style={{ background: "var(--card)", border: "1px solid var(--border)" }}
       >
         <p className="text-sm" style={{ color: "var(--muted)" }}>Price chart coming soon</p>
       </div>
+      </Suspense>
 
       {/* Trading interface + Recent trades */}
       <div className="grid sm:grid-cols-2 gap-4">

--- a/Frontend/app/page.tsx
+++ b/Frontend/app/page.tsx
@@ -1,5 +1,7 @@
 import FlightSearchAutocomplete from "./components/FlightSearchAutocomplete";
 import Link from "next/link";
+import { Suspense } from "react";
+import { MarketListSkeleton } from "./components/ui/Skeleton";
 
 const SAMPLE_MARKETS = [
   { id: "1", title: "Will AA123 arrive on time?", yesPrice: 0.62, volume: 14820, status: "open" },
@@ -28,6 +30,7 @@ export default function Home() {
         <h2 className="text-sm font-semibold mb-3" style={{ color: "var(--muted)" }}>
           ACTIVE MARKETS
         </h2>
+        <Suspense fallback={<MarketListSkeleton count={3} />}>
         <div className="space-y-2">
           {SAMPLE_MARKETS.map((m) => (
             <Link
@@ -53,6 +56,7 @@ export default function Home() {
             </Link>
           ))}
         </div>
+        </Suspense>
       </section>
     </main>
   );

--- a/Frontend/app/transactions/page.tsx
+++ b/Frontend/app/transactions/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Suspense } from "react";
+import TransactionHistory from "../components/transactions/TransactionHistory";
+import { TransactionTableSkeleton } from "../components/ui/Skeleton";
+
+export default function TransactionsPage() {
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-10 space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold" style={{ color: "var(--foreground)" }}>
+          Transaction History
+        </h1>
+        <p className="text-sm mt-1" style={{ color: "var(--muted)" }}>
+          All your trades, deposits, and redemptions in one place.
+        </p>
+      </div>
+
+      <Suspense fallback={<TransactionTableSkeleton rows={10} />}>
+        <TransactionHistory />
+      </Suspense>
+    </main>
+  );
+}

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@particle-network/connectkit": "^3.0.0-alpha.4",
         "@tanstack/react-query": "^5.99.2",
+        "@tanstack/react-table": "^8.21.3",
+        "date-fns": "^4.1.0",
+        "framer-motion": "^12.38.0",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -4856,6 +4859,39 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -7191,6 +7227,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "@particle-network/connectkit": "^3.0.0-alpha.4",
     "@tanstack/react-query": "^5.99.2",
+    "@tanstack/react-table": "^8.21.3",
+    "date-fns": "^4.1.0",
+    "framer-motion": "^12.38.0",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION


Closes  #6
closes  #7

Task 1 — `TransactionHistory` (`app/components/transactions/TransactionHistory.tsx`):
- Paginated table built with `@tanstack/react-table` (10/20/50 rows per page)
- Columns: date, type, market, amount, status, tx hash — all sortable
- Filter by transaction type (dropdown) and date range (from/to date pickers)
- CSV export of the current filtered view via `date-fns` formatted filenames
- Wired into a new `/transactions` page with a `Suspense` fallback

Task 2 — `Skeleton` components (`app/components/ui/Skeleton.tsx`):
- Base `Skeleton` block with Framer Motion shimmer animation
- Composed variants: `MarketCardSkeleton`, `MarketListSkeleton`, `StatsSkeleton`, `ChartSkeleton`, `TransactionTableSkeleton`
- Applied to home page market list, market detail stats + chart, and the transactions page
- No layout shift — skeleton dimensions match actual content