### PR TITLE
feat: add market status indicators and badges

### DIFF
--- a/Frontend/app/markets/[id]/page.tsx
+++ b/Frontend/app/markets/[id]/page.tsx
@@ -1,18 +1,21 @@
 "use client";
 import { useState, Suspense } from "react";
 import { StatsSkeleton, ChartSkeleton } from "../../components/ui/Skeleton";
+import StatusIndicator from "../../../components/market/StatusIndicator";
 
 // Mock data — replace with real contract/API calls
 const MOCK_MARKET = {
   id: "1",
   title: "Will AA123 arrive on time?",
   description: "American Airlines flight AA123 from JFK to LAX on Apr 25, 2026.",
-  status: "open" as "open" | "closed" | "resolved",
+  status: "open" as "open" | "closed" | "resolved" | "disputed",
   yesPrice: 0.62,
   noPrice: 0.38,
   volume: 14820,
   liquidity: 5400,
   participants: 87,
+  resolvedAt: undefined as string | undefined,
+  outcome: undefined as "YES" | "NO" | undefined,
   recentTrades: [
     { side: "YES", amount: 50, price: 0.62, time: "2m ago" },
     { side: "NO", amount: 120, price: 0.38, time: "5m ago" },
@@ -20,12 +23,6 @@ const MOCK_MARKET = {
     { side: "NO", amount: 75, price: 0.39, time: "18m ago" },
     { side: "YES", amount: 300, price: 0.60, time: "25m ago" },
   ],
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  open: "#22c55e",
-  closed: "#f59e0b",
-  resolved: "#6366f1",
 };
 
 export default function MarketDetailPage({ params }: { params: { id: string } }) {
@@ -42,12 +39,12 @@ export default function MarketDetailPage({ params }: { params: { id: string } })
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
           <div className="flex items-center gap-2 mb-1">
-            <span
-              className="text-xs font-semibold px-2 py-0.5 rounded-full"
-              style={{ background: STATUS_COLORS[market.status] + "22", color: STATUS_COLORS[market.status] }}
-            >
-              {market.status.toUpperCase()}
-            </span>
+            <StatusIndicator
+              status={market.status}
+              resolvedAt={market.resolvedAt}
+              outcome={market.outcome}
+              variant="full"
+            />
             <span className="text-xs" style={{ color: "var(--muted)" }}>Market #{market.id}</span>
           </div>
           <h1 className="text-xl font-semibold" style={{ color: "var(--foreground)" }}>{market.title}</h1>

--- a/Frontend/components/market/MarketCard.tsx
+++ b/Frontend/components/market/MarketCard.tsx
@@ -1,24 +1,21 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import StatusIndicator, { MarketStatus } from "./StatusIndicator";
 
 export interface Market {
   id: string;
   title: string;
   description: string;
-  status: "open" | "closed" | "resolved";
+  status: MarketStatus;
   yesPrice: number;
   noPrice: number;
   volume: number;
   liquidity: number;
+  resolvedAt?: string;
+  outcome?: "YES" | "NO";
   image?: string;
 }
-
-const STATUS_STYLES: Record<Market["status"], { bg: string; color: string; label: string }> = {
-  open:     { bg: "#22c55e22", color: "#22c55e", label: "OPEN" },
-  closed:   { bg: "#f59e0b22", color: "#f59e0b", label: "CLOSED" },
-  resolved: { bg: "#6366f122", color: "#6366f1", label: "RESOLVED" },
-};
 
 interface MarketCardProps {
   market: Market;
@@ -38,7 +35,7 @@ export default function MarketCard({ market, onClick }: MarketCardProps) {
     return () => clearInterval(id);
   }, [market.yesPrice, market.noPrice, market.status]);
 
-  const status = STATUS_STYLES[market.status];
+  const status = market.status;
 
   return (
     <Link
@@ -68,12 +65,9 @@ export default function MarketCard({ market, onClick }: MarketCardProps) {
         {/* Status + title */}
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
-            <span
-              className="inline-block text-xs font-semibold px-2 py-0.5 rounded-full mb-1"
-              style={{ background: status.bg, color: status.color }}
-            >
-              {status.label}
-            </span>
+            <div className="mb-1">
+              <StatusIndicator status={status} resolvedAt={market.resolvedAt} outcome={market.outcome} variant="full" />
+            </div>
             <h3
               className="font-semibold text-sm leading-snug line-clamp-2"
               style={{ color: "var(--foreground)" }}

--- a/Frontend/components/market/StatusIndicator.tsx
+++ b/Frontend/components/market/StatusIndicator.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+
+export type MarketStatus = "open" | "closed" | "resolved" | "disputed";
+
+interface StatusIndicatorProps {
+  status: MarketStatus;
+  resolvedAt?: string;   // ISO date string
+  outcome?: "YES" | "NO";
+  /** "badge" = pill only, "full" = pill + resolution details */
+  variant?: "badge" | "full";
+}
+
+const CONFIG: Record<MarketStatus, { label: string; color: string; dot: string }> = {
+  open:     { label: "Active",   color: "#22c55e", dot: "animate-pulse" },
+  closed:   { label: "Closed",   color: "#f59e0b", dot: "" },
+  resolved: { label: "Resolved", color: "#6366f1", dot: "" },
+  disputed: { label: "Disputed", color: "#ef4444", dot: "animate-pulse" },
+};
+
+export default function StatusIndicator({
+  status,
+  resolvedAt,
+  outcome,
+  variant = "badge",
+}: StatusIndicatorProps) {
+  const cfg = CONFIG[status];
+
+  // Tick every second so "live" markets feel real-time
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (status !== "open" && status !== "disputed") return;
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [status]);
+
+  const badge = (
+    <span
+      className="inline-flex items-center gap-1.5 text-xs font-semibold px-2 py-0.5 rounded-full"
+      style={{ background: cfg.color + "22", color: cfg.color }}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${cfg.dot}`}
+        style={{ background: cfg.color }}
+      />
+      {cfg.label}
+    </span>
+  );
+
+  if (variant === "badge") return badge;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {badge}
+      {status === "resolved" && (outcome || resolvedAt) && (
+        <div className="flex items-center gap-2 text-xs" style={{ color: "var(--muted)" }}>
+          {outcome && (
+            <span
+              className="font-semibold"
+              style={{ color: outcome === "YES" ? "#22c55e" : "#ef4444" }}
+            >
+              Outcome: {outcome}
+            </span>
+          )}
+          {resolvedAt && (
+            <span>· {new Date(resolvedAt).toLocaleDateString(undefined, { dateStyle: "medium" })}</span>
+          )}
+        </div>
+      )}
+      {status === "disputed" && (
+        <p className="text-xs" style={{ color: "#ef4444" }}>
+          Under review — outcome pending
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add StatusIndicator component with Active, Closed, Resolved, Disputed states
- Color-coded badges: green (active), amber (closed), indigo (resolved), red (disputed)
- Pulsing dot on active and disputed markets for real-time feel
- Full variant shows resolution date and YES/NO outcome on resolved markets
- Replace inline badge logic in MarketCard and market detail page
- Extend Market type to include disputed status, resolvedAt, and outcome fields

closes #18 