### PR TITLE
feat: implement FeeHandler contract for trading fee management

### DIFF
--- a/Contracts/contracts/FeeHandler.sol
+++ b/Contracts/contracts/FeeHandler.sol
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20}          from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20}        from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable}          from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard}  from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {mulDiv}           from "@prb/math/src/Common.sol";
+
+/**
+ * @title  FeeHandler
+ * @notice Central contract for calculating, collecting, and distributing trading fees.
+ *
+ * Fee structures are keyed by an arbitrary bytes32 id (e.g. keccak256("TRADING")).
+ * Each structure defines:
+ *   - a fee rate in basis points (max 10 %)
+ *   - an ordered list of recipients whose shareBps values sum to 10 000
+ *
+ * Two collection paths are supported:
+ *   1. collectAndDistribute — pulls the fee from the caller (requires allowance) then
+ *      immediately distributes to all recipients.
+ *   2. distribute — distributes tokens already present in this contract; useful when a
+ *      sibling contract has pre-transferred the fee amount here.
+ *
+ * All fees are tracked per-structure and per-token for off-chain and on-chain querying.
+ */
+contract FeeHandler is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ── Constants ──────────────────────────────────────────────────────────────
+
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    uint256 public constant MAX_FEE_BPS     = 1_000; // 10 % ceiling
+
+    // ── Types ──────────────────────────────────────────────────────────────────
+
+    struct FeeRecipient {
+        address account;
+        uint256 shareBps; // fraction of fee; all recipients must sum to BPS_DENOMINATOR
+    }
+
+    struct FeeStructure {
+        uint256        feeBps;
+        bool           active;
+        FeeRecipient[] recipients;
+    }
+
+    // ── State ──────────────────────────────────────────────────────────────────
+
+    mapping(bytes32 => FeeStructure)                private _structures;
+
+    // structureId => token => cumulative fee amount collected
+    mapping(bytes32 => mapping(address => uint256)) private _collected;
+
+    // token => cumulative fee amount collected across all structures
+    mapping(address => uint256)                     private _totalCollected;
+
+    // ── Events ─────────────────────────────────────────────────────────────────
+
+    event FeeStructureSet(bytes32 indexed id, uint256 feeBps, uint256 recipientCount);
+    event FeeStructureDeactivated(bytes32 indexed id);
+    event FeesDistributed(bytes32 indexed id, address indexed token, uint256 feeAmount);
+
+    // ── Errors ─────────────────────────────────────────────────────────────────
+
+    error StructureNotActive(bytes32 id);
+    error FeeTooHigh();
+    error InvalidRecipients();
+    error ZeroAmount();
+    error ZeroAddress();
+
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    constructor() Ownable(msg.sender) {}
+
+    // ── Admin ──────────────────────────────────────────────────────────────────
+
+    /**
+     * @notice Create or replace a fee structure.
+     * @param id         Arbitrary identifier (e.g. keccak256("TRADING")).
+     * @param feeBps     Fee rate in basis points. Must be ≤ MAX_FEE_BPS.
+     * @param recipients List of recipients; shareBps must sum to BPS_DENOMINATOR.
+     */
+    function setFeeStructure(
+        bytes32              id,
+        uint256              feeBps,
+        FeeRecipient[] calldata recipients
+    ) external onlyOwner {
+        if (feeBps > MAX_FEE_BPS)   revert FeeTooHigh();
+        if (recipients.length == 0) revert InvalidRecipients();
+
+        uint256 shareSum;
+        for (uint256 i; i < recipients.length; ++i) {
+            if (recipients[i].account == address(0)) revert ZeroAddress();
+            shareSum += recipients[i].shareBps;
+        }
+        if (shareSum != BPS_DENOMINATOR) revert InvalidRecipients();
+
+        FeeStructure storage fs = _structures[id];
+        fs.feeBps = feeBps;
+        fs.active = true;
+
+        // Reset existing recipients then rebuild.
+        delete fs.recipients;
+        for (uint256 i; i < recipients.length; ++i) {
+            fs.recipients.push(recipients[i]);
+        }
+
+        emit FeeStructureSet(id, feeBps, recipients.length);
+    }
+
+    /// @notice Disable a fee structure; any collection attempt will revert.
+    function deactivateFeeStructure(bytes32 id) external onlyOwner {
+        _structures[id].active = false;
+        emit FeeStructureDeactivated(id);
+    }
+
+    // ── Fee calculation ────────────────────────────────────────────────────────
+
+    /**
+     * @notice Calculate the fee for a given gross amount under structure `id`.
+     * @param grossAmount Pre-fee amount in token units.
+     * @param id          Fee structure to apply.
+     * @return feeAmount  Fee in the same token units as grossAmount.
+     */
+    function calculateFee(uint256 grossAmount, bytes32 id)
+        public
+        view
+        returns (uint256 feeAmount)
+    {
+        if (!_structures[id].active) revert StructureNotActive(id);
+        // mulDiv avoids phantom overflow: floor(grossAmount * feeBps / BPS_DENOMINATOR)
+        feeAmount = mulDiv(grossAmount, _structures[id].feeBps, BPS_DENOMINATOR);
+    }
+
+    // ── Collection ─────────────────────────────────────────────────────────────
+
+    /**
+     * @notice Pull the fee from the caller and immediately distribute it to all
+     *         recipients. The caller must have approved this contract for at least
+     *         the fee amount (computed internally from grossAmount and feeBps).
+     *
+     * @param token       ERC-20 token in which fees are denominated.
+     * @param grossAmount The gross (pre-fee) amount used to derive the fee.
+     * @param id          Fee structure to apply.
+     * @return feeAmount  Tokens collected and distributed.
+     */
+    function collectAndDistribute(
+        address token,
+        uint256 grossAmount,
+        bytes32 id
+    ) external nonReentrant returns (uint256 feeAmount) {
+        if (token == address(0)) revert ZeroAddress();
+        if (grossAmount == 0)    revert ZeroAmount();
+
+        feeAmount = calculateFee(grossAmount, id);
+        if (feeAmount == 0) return 0;
+
+        IERC20(token).safeTransferFrom(msg.sender, address(this), feeAmount);
+        _distribute(token, feeAmount, id);
+    }
+
+    /**
+     * @notice Distribute tokens already held by this contract to fee recipients.
+     *         Useful when the calling contract has pre-transferred the exact fee
+     *         amount to this address.
+     *
+     * @param token      ERC-20 token to distribute.
+     * @param feeAmount  Exact amount to distribute.
+     * @param id         Fee structure that defines the recipient split.
+     */
+    function distribute(
+        address token,
+        uint256 feeAmount,
+        bytes32 id
+    ) external nonReentrant {
+        if (token == address(0))           revert ZeroAddress();
+        if (feeAmount == 0)                revert ZeroAmount();
+        if (!_structures[id].active)       revert StructureNotActive(id);
+        _distribute(token, feeAmount, id);
+    }
+
+    // ── Queries ────────────────────────────────────────────────────────────────
+
+    /// @notice Return the full configuration of a fee structure.
+    function getFeeStructure(bytes32 id)
+        external
+        view
+        returns (uint256 feeBps, bool active, FeeRecipient[] memory recipients)
+    {
+        FeeStructure storage fs = _structures[id];
+        return (fs.feeBps, fs.active, fs.recipients);
+    }
+
+    /// @notice Cumulative fees collected under a specific structure for a given token.
+    function getCollectedFees(bytes32 id, address token)
+        external
+        view
+        returns (uint256)
+    {
+        return _collected[id][token];
+    }
+
+    /// @notice Cumulative fees collected across all structures for a given token.
+    function getTotalCollectedFees(address token) external view returns (uint256) {
+        return _totalCollected[token];
+    }
+
+    // ── Internal ───────────────────────────────────────────────────────────────
+
+    function _distribute(address token, uint256 feeAmount, bytes32 id) internal {
+        FeeRecipient[] storage recipients = _structures[id].recipients;
+        uint256 n = recipients.length;
+        uint256 distributed;
+
+        for (uint256 i; i < n; ++i) {
+            uint256 share;
+            if (i == n - 1) {
+                // Last recipient absorbs any dust from integer division.
+                share = feeAmount - distributed;
+            } else {
+                share = mulDiv(feeAmount, recipients[i].shareBps, BPS_DENOMINATOR);
+                distributed += share;
+            }
+            if (share > 0) IERC20(token).safeTransfer(recipients[i].account, share);
+        }
+
+        _collected[id][token]  += feeAmount;
+        _totalCollected[token] += feeAmount;
+
+        emit FeesDistributed(id, token, feeAmount);
+    }
+}

--- a/Contracts/foundry.toml
+++ b/Contracts/foundry.toml
@@ -1,15 +1,4 @@
 [profile.default]
-<<<<<<< feat/amm-pool
-src             = "contracts"
-out             = "out"
-libs            = ["lib"]
-test            = "test"
-script          = "script"
-solc            = "0.8.20"
-optimizer       = true
-optimizer_runs  = 200
-via_ir          = true
-=======
 src            = "contracts"
 out            = "out"
 libs           = ["lib"]
@@ -19,7 +8,6 @@ solc           = "0.8.20"
 optimizer      = true
 optimizer_runs = 200
 via_ir         = true
->>>>>>> main
 
 [profile.default.fuzz]
 runs = 256
@@ -28,10 +16,4 @@ runs = 256
 mainnet = "${MAINNET_RPC_URL}"
 
 [etherscan]
-<<<<<<< feat/amm-pool
 mainnet = { key = "${ETHERSCAN_API_KEY}" }
-
-# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
-=======
-mainnet = { key = "${ETHERSCAN_API_KEY}" }
->>>>>>> main

--- a/Contracts/test/FeeHandler.t.sol
+++ b/Contracts/test/FeeHandler.t.sol
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test}        from "forge-std/Test.sol";
+import {ERC20}       from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {FeeHandler}  from "../contracts/FeeHandler.sol";
+
+// ─── Mock ERC20 ────────────────────────────────────────────────────────────────
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+// ─── FeeHandlerTest ────────────────────────────────────────────────────────────
+
+contract FeeHandlerTest is Test {
+    // ── Actors ────────────────────────────────────────────────────────────────
+    address alice   = makeAddr("alice");
+    address bob     = makeAddr("bob");
+    address charlie = makeAddr("charlie");
+    address payer   = makeAddr("payer");
+
+    // ── Contracts ─────────────────────────────────────────────────────────────
+    FeeHandler handler;
+    MockERC20  token;
+
+    // ── Fee structure ids ─────────────────────────────────────────────────────
+    bytes32 constant TRADING    = keccak256("TRADING");
+    bytes32 constant WITHDRAWAL = keccak256("WITHDRAWAL");
+
+    // ── Setup ─────────────────────────────────────────────────────────────────
+
+    function setUp() public {
+        handler = new FeeHandler();
+        token   = new MockERC20("Test Token", "TT");
+
+        token.mint(payer, 1_000_000 ether);
+        vm.prank(payer);
+        token.approve(address(handler), type(uint256).max);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    function _single(bytes32 id, uint256 feeBps, address recipient) internal {
+        FeeHandler.FeeRecipient[] memory r = new FeeHandler.FeeRecipient[](1);
+        r[0] = FeeHandler.FeeRecipient({account: recipient, shareBps: 10_000});
+        handler.setFeeStructure(id, feeBps, r);
+    }
+
+    function _split5050(bytes32 id, uint256 feeBps) internal {
+        FeeHandler.FeeRecipient[] memory r = new FeeHandler.FeeRecipient[](2);
+        r[0] = FeeHandler.FeeRecipient({account: alice, shareBps: 5_000});
+        r[1] = FeeHandler.FeeRecipient({account: bob,   shareBps: 5_000});
+        handler.setFeeStructure(id, feeBps, r);
+    }
+
+    // ── setFeeStructure ───────────────────────────────────────────────────────
+
+    function test_setFeeStructure_ownerCanCreate() public {
+        _single(TRADING, 30, alice);
+
+        (uint256 feeBps, bool active, FeeHandler.FeeRecipient[] memory r) =
+            handler.getFeeStructure(TRADING);
+
+        assertEq(feeBps, 30);
+        assertTrue(active);
+        assertEq(r.length, 1);
+        assertEq(r[0].account, alice);
+        assertEq(r[0].shareBps, 10_000);
+    }
+
+    function test_setFeeStructure_revertsOnFeeTooHigh() public {
+        FeeHandler.FeeRecipient[] memory r = new FeeHandler.FeeRecipient[](1);
+        r[0] = FeeHandler.FeeRecipient({account: alice, shareBps: 10_000});
+        vm.expectRevert(FeeHandler.FeeTooHigh.selector);
+        handler.setFeeStructure(TRADING, 1_001, r);
+    }
+
+    function test_setFeeStructure_revertsOnInvalidShareSum() public {
+        FeeHandler.FeeRecipient[] memory r = new FeeHandler.FeeRecipient[](2);
+        r[0] = FeeHandler.FeeRecipient({account: alice, shareBps: 4_000});
+        r[1] = FeeHandler.FeeRecipient({account: bob,   shareBps: 4_000}); // sum = 8 000
+        vm.expectRevert(FeeHandler.InvalidRecipients.selector);
+        handler.setFeeStructure(TRADING, 30, r);
+    }
+
+    function test_setFeeStructure_revertsOnZeroAddress() public {
+        FeeHandler.FeeRecipient[] memory r = new FeeHandler.FeeRecipient[](1);
+        r[0] = FeeHandler.FeeRecipient({account: address(0), shareBps: 10_000});
+        vm.expectRevert(FeeHandler.ZeroAddress.selector);
+        handler.setFeeStructure(TRADING, 30, r);
+    }
+
+    function test_setFeeStructure_revertsForNonOwner() public {
+        FeeHandler.FeeRecipient[] memory r = new FeeHandler.FeeRecipient[](1);
+        r[0] = FeeHandler.FeeRecipient({account: alice, shareBps: 10_000});
+        vm.prank(alice);
+        vm.expectRevert();
+        handler.setFeeStructure(TRADING, 30, r);
+    }
+
+    function test_setFeeStructure_replacesRecipients() public {
+        _single(TRADING, 30, alice);
+        _split5050(TRADING, 50);
+
+        (, , FeeHandler.FeeRecipient[] memory r) = handler.getFeeStructure(TRADING);
+        assertEq(r.length, 2);
+        assertEq(r[0].account, alice);
+        assertEq(r[1].account, bob);
+    }
+
+    // ── calculateFee ──────────────────────────────────────────────────────────
+
+    function test_calculateFee_correctAmount() public {
+        _single(TRADING, 30, alice); // 0.30 %
+        // 0.30 % of 10 000 ether = 30 ether
+        assertEq(handler.calculateFee(10_000 ether, TRADING), 30 ether);
+    }
+
+    function test_calculateFee_multipleStructures() public {
+        _single(TRADING,    30, alice); // 0.30 %
+        _single(WITHDRAWAL, 50, bob);   // 0.50 %
+
+        assertEq(handler.calculateFee(10_000 ether, TRADING),    30 ether);
+        assertEq(handler.calculateFee(10_000 ether, WITHDRAWAL), 50 ether);
+    }
+
+    function test_calculateFee_revertsOnInactiveStructure() public {
+        vm.expectRevert(abi.encodeWithSelector(FeeHandler.StructureNotActive.selector, TRADING));
+        handler.calculateFee(1 ether, TRADING);
+    }
+
+    // ── collectAndDistribute ──────────────────────────────────────────────────
+
+    function test_collectAndDistribute_singleRecipient() public {
+        _single(TRADING, 30, alice); // 0.30 %
+        uint256 aliceBefore = token.balanceOf(alice);
+
+        vm.prank(payer);
+        uint256 fee = handler.collectAndDistribute(address(token), 10_000 ether, TRADING);
+
+        assertEq(fee, 30 ether);
+        assertEq(token.balanceOf(alice) - aliceBefore, 30 ether);
+    }
+
+    function test_collectAndDistribute_split5050() public {
+        _split5050(TRADING, 100); // 1 %
+
+        vm.prank(payer);
+        handler.collectAndDistribute(address(token), 10_000 ether, TRADING);
+
+        // fee = 100 ether split 50 / 50
+        assertEq(token.balanceOf(alice), 50 ether);
+        assertEq(token.balanceOf(bob),   50 ether);
+    }
+
+    function test_collectAndDistribute_threeRecipients() public {
+        FeeHandler.FeeRecipient[] memory r = new FeeHandler.FeeRecipient[](3);
+        r[0] = FeeHandler.FeeRecipient({account: alice,   shareBps: 5_000}); // 50 %
+        r[1] = FeeHandler.FeeRecipient({account: bob,     shareBps: 3_000}); // 30 %
+        r[2] = FeeHandler.FeeRecipient({account: charlie, shareBps: 2_000}); // 20 %
+        handler.setFeeStructure(TRADING, 100, r); // 1 %
+
+        vm.prank(payer);
+        handler.collectAndDistribute(address(token), 10_000 ether, TRADING);
+
+        // fee = 100 ether
+        assertEq(token.balanceOf(alice),   50 ether);
+        assertEq(token.balanceOf(bob),     30 ether);
+        assertEq(token.balanceOf(charlie), 20 ether);
+    }
+
+    function test_collectAndDistribute_pullsExactFeeFromPayer() public {
+        _single(TRADING, 30, alice);
+        uint256 payerBefore = token.balanceOf(payer);
+
+        vm.prank(payer);
+        uint256 fee = handler.collectAndDistribute(address(token), 10_000 ether, TRADING);
+
+        assertEq(payerBefore - token.balanceOf(payer), fee, "payer spent exactly the fee");
+    }
+
+    function test_collectAndDistribute_revertsOnInactiveStructure() public {
+        vm.expectRevert(abi.encodeWithSelector(FeeHandler.StructureNotActive.selector, TRADING));
+        vm.prank(payer);
+        handler.collectAndDistribute(address(token), 1 ether, TRADING);
+    }
+
+    // ── distribute ────────────────────────────────────────────────────────────
+
+    function test_distribute_usesPreTransferredFunds() public {
+        _single(TRADING, 30, alice);
+        uint256 feeAmount = 50 ether;
+        token.mint(address(handler), feeAmount);
+
+        uint256 aliceBefore = token.balanceOf(alice);
+        handler.distribute(address(token), feeAmount, TRADING);
+
+        assertEq(token.balanceOf(alice) - aliceBefore, feeAmount);
+    }
+
+    function test_distribute_revertsOnInactiveStructure() public {
+        token.mint(address(handler), 1 ether);
+        vm.expectRevert(abi.encodeWithSelector(FeeHandler.StructureNotActive.selector, TRADING));
+        handler.distribute(address(token), 1 ether, TRADING);
+    }
+
+    // ── Fee tracking ──────────────────────────────────────────────────────────
+
+    function test_tracking_accumulatesAcrossMultipleCalls() public {
+        _single(TRADING, 30, alice);
+
+        vm.prank(payer);
+        handler.collectAndDistribute(address(token), 10_000 ether, TRADING); // fee = 30
+
+        vm.prank(payer);
+        handler.collectAndDistribute(address(token), 5_000 ether, TRADING);  // fee = 15
+
+        assertEq(handler.getCollectedFees(TRADING, address(token)), 45 ether);
+        assertEq(handler.getTotalCollectedFees(address(token)),      45 ether);
+    }
+
+    function test_tracking_separateByStructure() public {
+        _single(TRADING,    30, alice);
+        _single(WITHDRAWAL, 50, bob);
+
+        vm.prank(payer);
+        handler.collectAndDistribute(address(token), 10_000 ether, TRADING);    // fee = 30
+
+        vm.prank(payer);
+        handler.collectAndDistribute(address(token), 2_000 ether, WITHDRAWAL);  // fee = 10
+
+        assertEq(handler.getCollectedFees(TRADING,    address(token)), 30 ether);
+        assertEq(handler.getCollectedFees(WITHDRAWAL, address(token)), 10 ether);
+        assertEq(handler.getTotalCollectedFees(address(token)),         40 ether);
+    }
+
+    // ── Deactivation ──────────────────────────────────────────────────────────
+
+    function test_deactivate_preventsCollection() public {
+        _single(TRADING, 30, alice);
+        handler.deactivateFeeStructure(TRADING);
+
+        vm.prank(payer);
+        vm.expectRevert(abi.encodeWithSelector(FeeHandler.StructureNotActive.selector, TRADING));
+        handler.collectAndDistribute(address(token), 1 ether, TRADING);
+    }
+
+    function test_deactivate_revertsForNonOwner() public {
+        _single(TRADING, 30, alice);
+        vm.prank(alice);
+        vm.expectRevert();
+        handler.deactivateFeeStructure(TRADING);
+    }
+
+    function test_deactivate_canBeReactivated() public {
+        _single(TRADING, 30, alice);
+        handler.deactivateFeeStructure(TRADING);
+        // Reactivate by calling setFeeStructure again
+        _single(TRADING, 30, alice);
+
+        vm.prank(payer);
+        uint256 fee = handler.collectAndDistribute(address(token), 10_000 ether, TRADING);
+        assertEq(fee, 30 ether);
+    }
+
+    // ── Fuzz tests ────────────────────────────────────────────────────────────
+
+    function testFuzz_calculateFee_neverExceedsGross(uint256 gross, uint256 feeBps) public {
+        feeBps = bound(feeBps, 1, handler.MAX_FEE_BPS());
+        gross  = bound(gross, 1, type(uint128).max);
+
+        _single(TRADING, feeBps, alice);
+        uint256 fee = handler.calculateFee(gross, TRADING);
+        assertLe(fee, gross, "fee must not exceed gross");
+    }
+
+    function testFuzz_distribute_totalEqualsInput(uint256 feeAmount) public {
+        feeAmount = bound(feeAmount, 2, type(uint128).max);
+
+        // 3-recipient split: 50 / 30 / 20
+        FeeHandler.FeeRecipient[] memory r = new FeeHandler.FeeRecipient[](3);
+        r[0] = FeeHandler.FeeRecipient({account: alice,   shareBps: 5_000});
+        r[1] = FeeHandler.FeeRecipient({account: bob,     shareBps: 3_000});
+        r[2] = FeeHandler.FeeRecipient({account: charlie, shareBps: 2_000});
+        handler.setFeeStructure(TRADING, 30, r);
+
+        token.mint(address(handler), feeAmount);
+        handler.distribute(address(token), feeAmount, TRADING);
+
+        uint256 received = token.balanceOf(alice) + token.balanceOf(bob) + token.balanceOf(charlie);
+        assertEq(received, feeAmount, "all fee tokens must be distributed");
+    }
+
+    function testFuzz_collectAndDistribute_noContractResidue(uint256 gross) public {
+        gross = bound(gross, 1 ether, 100_000 ether);
+        _split5050(TRADING, 30);
+
+        token.mint(payer, gross);
+        vm.prank(payer);
+        token.approve(address(handler), gross);
+
+        uint256 contractBefore = token.balanceOf(address(handler));
+
+        vm.prank(payer);
+        handler.collectAndDistribute(address(token), gross, TRADING);
+
+        // Handler should hold no residue after distribution
+        assertEq(token.balanceOf(address(handler)), contractBefore, "no tokens left in handler");
+    }
+}

--- a/Contracts/test/LMSR.t.sol
+++ b/Contracts/test/LMSR.t.sol
@@ -79,7 +79,7 @@ contract LMSRTest is Test {
         int256 c3 = lmsr.cost(q0, q2, B);
 
         // c1 + c2 should equal c3 (path independence)
-        assertApproxEqAbs(c1 + c2, c3, int256(WAD / 1000));
+        assertApproxEqAbs(c1 + c2, c3, uint256(WAD / 1000));
     }
 
     // ── Higher b → lower price impact ────────────────────────────────────────

--- a/Contracts/test/LiquidityPool.t.sol
+++ b/Contracts/test/LiquidityPool.t.sol
@@ -7,6 +7,8 @@ import "../src/ERC20Token.sol";
 import "../src/MarketFactory.sol";
 
 contract LiquidityPoolTest is Test {
+    event LiquidityChanged(address indexed provider, bool isDeposit, uint256 collateralAmount, uint256 lpAmount);
+
     ERC20Token internal collateral;
     LiquidityPool internal pool;
 
@@ -184,7 +186,7 @@ contract LiquidityPoolTest is Test {
         collateral.approve(address(pool), amount);
 
         vm.expectEmit(true, false, false, true);
-        emit LiquidityPool.LiquidityChanged(alice, true, amount, amount); // first deposit: lpMinted == amount
+        emit LiquidityChanged(alice, true, amount, amount); // first deposit: lpMinted == amount
         pool.deposit(amount);
         vm.stopPrank();
     }
@@ -198,7 +200,7 @@ contract LiquidityPoolTest is Test {
 
         vm.startPrank(alice);
         vm.expectEmit(true, false, false, true);
-        emit LiquidityPool.LiquidityChanged(alice, false, amount, lpBalance);
+        emit LiquidityChanged(alice, false, amount, lpBalance);
         pool.withdraw(lpBalance);
         vm.stopPrank();
     }

--- a/Contracts/test/MarketFactory.t.sol
+++ b/Contracts/test/MarketFactory.t.sol
@@ -6,6 +6,8 @@ import "../src/MarketFactory.sol";
 import "../src/PositionToken.sol";
 
 contract MarketFactoryTest is Test {
+    event MarketCreated(address indexed market, address indexed creator, address indexed collateralToken, uint256 resolutionDeadline);
+
     PositionToken internal positionToken;
     MarketFactory internal factory;
 
@@ -118,7 +120,7 @@ contract MarketFactoryTest is Test {
         );
 
         vm.expectEmit(true, true, true, true);
-        emit MarketFactory.MarketCreated(expectedMarket, address(this), validToken, deadline);
+        emit MarketCreated(expectedMarket, address(this), validToken, deadline);
         factory.createMarket(validToken, deadline, 1 ether, "ipfs://meta");
     }
 

--- a/Contracts/test/MarketMaker.t.sol
+++ b/Contracts/test/MarketMaker.t.sol
@@ -37,7 +37,6 @@ contract MarketMakerTest is Test {
             string memory desc,
             uint256 b,
             uint256 numOutcomes,
-            ,
             bool resolved,
             ,
             address creator

--- a/Contracts/test/PositionToken.t.sol
+++ b/Contracts/test/PositionToken.t.sol
@@ -39,6 +39,9 @@ contract MockMarket {
 }
 
 contract PositionTokenTest is Test {
+    event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);
+    event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values);
+
     MockFactory factory;
     PositionToken token;
     MockMarket market;
@@ -107,7 +110,7 @@ contract PositionTokenTest is Test {
     function test_mint_emitsTransferSingle() public {
         uint256 id = token.yesId(address(market));
         vm.expectEmit(true, true, true, true);
-        emit PositionToken.TransferSingle(address(market), address(0), alice, id, 77);
+        emit TransferSingle(address(market), address(0), alice, id, 77);
         market.mint(alice, id, 77);
     }
 
@@ -141,7 +144,7 @@ contract PositionTokenTest is Test {
         ids[0] = yId; ids[1] = nId;
         amounts[0] = 10; amounts[1] = 20;
         vm.expectEmit(true, true, true, true);
-        emit PositionToken.TransferBatch(address(market), address(0), alice, ids, amounts);
+        emit TransferBatch(address(market), address(0), alice, ids, amounts);
         market.mintBatch(alice, ids, amounts);
     }
 

--- a/Contracts/test/Resolution.t.sol
+++ b/Contracts/test/Resolution.t.sol
@@ -19,6 +19,11 @@ contract ERC1155Holder {
 }
 
 contract ResolutionTest is Test {
+    event MarketResolved(address indexed market, Resolution.Outcome outcome, address indexed resolver);
+    event DisputeRaised(address indexed market, address indexed disputer, string evidenceURI);
+    event PayoutClaimed(address indexed market, address indexed claimant, uint256 amount);
+    event RefundClaimed(address indexed market, address indexed claimant, uint256 amount);
+
     // -------------------------------------------------------------------------
     // Contracts
     // -------------------------------------------------------------------------
@@ -412,7 +417,7 @@ contract ResolutionTest is Test {
         vm.warp(block.timestamp + 3 hours);
         vm.prank(resolverAddr);
         vm.expectEmit(true, false, true, true);
-        emit Resolution.MarketResolved(marketAddr, Resolution.Outcome.YES, resolverAddr);
+        emit MarketResolved(marketAddr, Resolution.Outcome.YES, resolverAddr);
         resolution.resolve(marketAddr, Resolution.Outcome.YES, bytes("data"));
     }
 
@@ -421,7 +426,7 @@ contract ResolutionTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, false, true);
-        emit Resolution.DisputeRaised(marketAddr, alice, "ipfs://evidence");
+        emit DisputeRaised(marketAddr, alice, "ipfs://evidence");
         resolution.dispute(marketAddr, "ipfs://evidence");
     }
 
@@ -436,7 +441,7 @@ contract ResolutionTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, false, true);
-        emit Resolution.PayoutClaimed(marketAddr, alice, expectedPayout);
+        emit PayoutClaimed(marketAddr, alice, expectedPayout);
         resolution.claimPayout(marketAddr);
     }
 
@@ -453,7 +458,7 @@ contract ResolutionTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, false, true);
-        emit Resolution.RefundClaimed(marketAddr, alice, expectedRefund);
+        emit RefundClaimed(marketAddr, alice, expectedRefund);
         resolution.claimRefund(marketAddr);
     }
 

--- a/Contracts/test/Trading.t.sol
+++ b/Contracts/test/Trading.t.sol
@@ -7,6 +7,8 @@ import "../src/MarketMaker.sol";
 import "../src/Trading.sol";
 
 contract TradingTest is Test {
+    event TradeExecuted(address indexed trader, uint256 indexed marketId, uint256 outcome, bool isBuy, uint256 shares, uint256 collateralAmount, uint256 fee);
+
     ERC20Token  token;
     MarketMaker mm;
     Trading     trading;
@@ -117,7 +119,7 @@ contract TradingTest is Test {
         vm.startPrank(alice);
         token.approve(address(trading), total);
         vm.expectEmit(true, true, false, false);
-        emit Trading.TradeExecuted(alice, marketId, 0, true, shares, total, fee);
+        emit TradeExecuted(alice, marketId, 0, true, shares, total, fee);
         trading.executeBuy(marketId, 0, shares, total);
         vm.stopPrank();
     }


### PR DESCRIPTION
Summary

Adds FeeHandler.sol — a central contract for calculating, collecting, and distributing trading fees
Supports multiple named fee structures (e.g. TRADING, WITHDRAWAL), each with its own rate and recipient split
Fees are distributed proportionally to an ordered list of recipients; the last recipient absorbs integer division dust
Two collection paths: collectAndDistribute (pulls from caller) and distribute (uses pre-transferred funds)
Full fee tracking per structure and per token via getCollectedFees and getTotalCollectedFees
Uses PRBMath mulDiv for overflow-safe fee and share calculations
Also fixes pre-existing Solidity 0.8.20 compilation errors in 7 team test files (emit ContractName.Event syntax not supported until 0.8.21, wrong cast in LMSR test, wrong tuple size in MarketMaker test)
Test plan

 24 unit + fuzz tests in test/FeeHandler.t.sol — all passing
 Fee calculation correctness (single and multiple structures)
 Distribution to 1, 2, and 3 recipients with exact share verification
 Protocol fee tracking across multiple calls and multiple structures
 Deactivation / reactivation of fee structures
 Fuzz: fee never exceeds gross amount
 Fuzz: sum of all recipient payouts always equals input fee amount
 Fuzz: no tokens left in contract after distribution
 
 closes #66 