### PR TITLE
implementation of gas fee estimation display & notification toast system

### DIFF
--- a/Frontend/app/components/ToastProvider.tsx
+++ b/Frontend/app/components/ToastProvider.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback, useReducer, useRef } from "react";
+import {
+  ToastContext,
+  type Toast,
+  type ToastInput,
+} from "../../hooks/useToast";
+import { ToastContainer } from "./ui/Toast";
+
+// ─── Reducer ──────────────────────────────────────────────────────────────────
+
+type Action =
+  | { type: "ADD"; toast: Toast }
+  | { type: "DISMISS"; id: string }
+  | { type: "DISMISS_ALL" };
+
+const MAX_TOASTS = 5;
+
+function reducer(state: Toast[], action: Action): Toast[] {
+  switch (action.type) {
+    case "ADD":
+      return [action.toast, ...state].slice(0, MAX_TOASTS);
+    case "DISMISS":
+      return state.filter((t) => t.id !== action.id);
+    case "DISMISS_ALL":
+      return [];
+    default:
+      return state;
+  }
+}
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, dispatch] = useReducer(reducer, []);
+  const counterRef = useRef(0);
+
+  const toast = useCallback((input: ToastInput): string => {
+    const id = `toast-${++counterRef.current}-${Date.now()}`;
+    const duration = input.duration !== undefined ? input.duration : 5000;
+    dispatch({ type: "ADD", toast: { ...input, id, duration } });
+    return id;
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    dispatch({ type: "DISMISS", id });
+  }, []);
+
+  const dismissAll = useCallback(() => {
+    dispatch({ type: "DISMISS_ALL" });
+  }, []);
+
+  const success = useCallback(
+    (title: string, message?: string, opts?: Partial<ToastInput>) =>
+      toast({ type: "success", title, message, ...opts }),
+    [toast]
+  );
+
+  const error = useCallback(
+    (title: string, message?: string, opts?: Partial<ToastInput>) =>
+      toast({ type: "error", title, message, duration: 7000, ...opts }),
+    [toast]
+  );
+
+  const warning = useCallback(
+    (title: string, message?: string, opts?: Partial<ToastInput>) =>
+      toast({ type: "warning", title, message, ...opts }),
+    [toast]
+  );
+
+  const info = useCallback(
+    (title: string, message?: string, opts?: Partial<ToastInput>) =>
+      toast({ type: "info", title, message, ...opts }),
+    [toast]
+  );
+
+  return (
+    <ToastContext.Provider
+      value={{ toasts, toast, dismiss, dismissAll, success, error, warning, info }}
+    >
+      {children}
+      <ToastContainer />
+    </ToastContext.Provider>
+  );
+}

--- a/Frontend/app/components/ui/Toast.tsx
+++ b/Frontend/app/components/ui/Toast.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useToast, type Toast } from "../../../hooks/useToast";
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+function IconSuccess() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+      <circle cx="10" cy="10" r="10" fill="currentColor" opacity="0.15" />
+      <path
+        d="M6 10.5l3 3 5-5"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function IconError() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+      <circle cx="10" cy="10" r="10" fill="currentColor" opacity="0.15" />
+      <path
+        d="M7 7l6 6M13 7l-6 6"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function IconWarning() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+      <path
+        d="M10 2L18.66 17H1.34L10 2z"
+        fill="currentColor"
+        opacity="0.15"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <path d="M10 8v4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <circle cx="10" cy="14.5" r="0.8" fill="currentColor" />
+    </svg>
+  );
+}
+
+function IconInfo() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+      <circle cx="10" cy="10" r="10" fill="currentColor" opacity="0.15" />
+      <path d="M10 9v5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <circle cx="10" cy="6.5" r="0.9" fill="currentColor" />
+    </svg>
+  );
+}
+
+function IconClose() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path
+        d="M2 2l10 10M12 2L2 12"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+// ─── Type config ──────────────────────────────────────────────────────────────
+
+const TYPE_CONFIG = {
+  success: {
+    icon: <IconSuccess />,
+    color: "#22c55e",
+    label: "Success",
+  },
+  error: {
+    icon: <IconError />,
+    color: "#ef4444",
+    label: "Error",
+  },
+  warning: {
+    icon: <IconWarning />,
+    color: "#f59e0b",
+    label: "Warning",
+  },
+  info: {
+    icon: <IconInfo />,
+    color: "#3b82f6",
+    label: "Info",
+  },
+} as const;
+
+// ─── Progress bar ─────────────────────────────────────────────────────────────
+
+function ProgressBar({
+  duration,
+  paused,
+  color,
+}: {
+  duration: number;
+  paused: boolean;
+  color: string;
+}) {
+  return (
+    <motion.div
+      initial={{ scaleX: 1 }}
+      animate={{ scaleX: paused ? undefined : 0 }}
+      transition={{ duration: duration / 1000, ease: "linear" }}
+      style={{
+        transformOrigin: "left",
+        height: 3,
+        background: color,
+        opacity: 0.6,
+        borderRadius: "0 0 8px 8px",
+      }}
+    />
+  );
+}
+
+// ─── Single toast item ────────────────────────────────────────────────────────
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const { dismiss } = useToast();
+  const pausedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef(toast.duration ?? 5000);
+  const startedAtRef = useRef(Date.now());
+
+  const config = TYPE_CONFIG[toast.type];
+
+  // Auto-dismiss with pause-on-hover support
+  useEffect(() => {
+    if (!toast.duration) return; // 0 = persistent
+
+    function start() {
+      timerRef.current = setTimeout(() => dismiss(toast.id), remainingRef.current);
+      startedAtRef.current = Date.now();
+    }
+
+    start();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [toast.id, toast.duration, dismiss]);
+
+  function handleMouseEnter() {
+    pausedRef.current = true;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      remainingRef.current -= Date.now() - startedAtRef.current;
+    }
+  }
+
+  function handleMouseLeave() {
+    pausedRef.current = false;
+    if (!toast.duration) return;
+    timerRef.current = setTimeout(() => dismiss(toast.id), remainingRef.current);
+    startedAtRef.current = Date.now();
+  }
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 24, scale: 0.95 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: -12, scale: 0.95 }}
+      transition={{ type: "spring", stiffness: 380, damping: 30 }}
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        background: "var(--card)",
+        border: `1px solid var(--border)`,
+        borderLeft: `4px solid ${config.color}`,
+        borderRadius: 10,
+        overflow: "hidden",
+        minWidth: 300,
+        maxWidth: 420,
+        boxShadow: "0 4px 24px rgba(0,0,0,0.12)",
+        pointerEvents: "all",
+      }}
+    >
+      {/* Body */}
+      <div className="flex items-start gap-3 px-4 py-3">
+        {/* Icon */}
+        <span style={{ color: config.color, flexShrink: 0, marginTop: 1 }}>
+          {config.icon}
+        </span>
+
+        {/* Text */}
+        <div className="flex-1 min-w-0">
+          {toast.title && (
+            <p
+              className="text-sm font-semibold leading-snug"
+              style={{ color: "var(--foreground)" }}
+            >
+              {toast.title}
+            </p>
+          )}
+          {toast.message && (
+            <p
+              className="text-sm leading-snug mt-0.5"
+              style={{ color: "var(--muted)" }}
+            >
+              {toast.message}
+            </p>
+          )}
+
+          {/* Action button */}
+          {toast.action && (
+            <button
+              onClick={() => {
+                toast.action!.onClick();
+                dismiss(toast.id);
+              }}
+              className="mt-2 text-xs font-semibold underline underline-offset-2 cursor-pointer"
+              style={{ color: config.color }}
+            >
+              {toast.action.label}
+            </button>
+          )}
+        </div>
+
+        {/* Dismiss button */}
+        <button
+          onClick={() => dismiss(toast.id)}
+          aria-label="Dismiss notification"
+          className="flex-shrink-0 cursor-pointer rounded-md p-1 transition-colors"
+          style={{ color: "var(--muted)" }}
+          onMouseEnter={(e) =>
+            ((e.currentTarget as HTMLButtonElement).style.color = "var(--foreground)")
+          }
+          onMouseLeave={(e) =>
+            ((e.currentTarget as HTMLButtonElement).style.color = "var(--muted)")
+          }
+        >
+          <IconClose />
+        </button>
+      </div>
+
+      {/* Progress bar */}
+      {!!toast.duration && (
+        <ProgressBar
+          duration={remainingRef.current}
+          paused={pausedRef.current}
+          color={config.color}
+        />
+      )}
+    </motion.div>
+  );
+}
+
+// ─── Toast container ──────────────────────────────────────────────────────────
+
+export function ToastContainer() {
+  const { toasts } = useToast();
+
+  return (
+    <div
+      aria-label="Notifications"
+      style={{
+        position: "fixed",
+        bottom: 24,
+        right: 24,
+        zIndex: 9999,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        alignItems: "flex-end",
+        pointerEvents: "none",
+      }}
+    >
+      <AnimatePresence initial={false} mode="sync">
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} />
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/Frontend/app/layout.tsx
+++ b/Frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { ParticleClientWrapper } from "./components/ParticleClientWrapper";
 import Navbar from "./components/Navbar";
+import { ToastProvider } from "./components/ToastProvider";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -18,10 +19,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
       <body className="min-h-full flex flex-col">
         <ThemeProvider>
-          <ParticleClientWrapper>
-            <Navbar />
-            <div className="flex-1">{children}</div>
-          </ParticleClientWrapper>
+          <ToastProvider>
+            <ParticleClientWrapper>
+              <Navbar />
+              <div className="flex-1">{children}</div>
+            </ParticleClientWrapper>
+          </ToastProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/Frontend/app/markets/[id]/page.tsx
+++ b/Frontend/app/markets/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useState, Suspense } from "react";
 import { StatsSkeleton, ChartSkeleton } from "../../components/ui/Skeleton";
 import StatusIndicator from "../../../components/market/StatusIndicator";
+import GasEstimator, { type GasSpeed, type GasEstimate } from "../../../components/gas/GasEstimator";
 
 // Mock data — replace with real contract/API calls
 const MOCK_MARKET = {
@@ -29,6 +30,8 @@ export default function MarketDetailPage({ params }: { params: { id: string } })
   const market = { ...MOCK_MARKET, id: params.id };
   const [side, setSide] = useState<"YES" | "NO">("YES");
   const [amount, setAmount] = useState("");
+  const [gasSpeed, setGasSpeed] = useState<GasSpeed>("standard");
+  const [gasEstimate, setGasEstimate] = useState<GasEstimate | null>(null);
 
   const price = side === "YES" ? market.yesPrice : market.noPrice;
   const shares = amount ? (parseFloat(amount) / price).toFixed(2) : "—";
@@ -119,6 +122,25 @@ export default function MarketDetailPage({ params }: { params: { id: string } })
           <div className="flex justify-between text-xs" style={{ color: "var(--muted)" }}>
             <span>Estimated shares</span><span>{shares}</span>
           </div>
+          {/* Gas fee estimate */}
+          <GasEstimator
+            compact
+            defaultSpeed={gasSpeed}
+            onSelect={(speed, estimate) => {
+              setGasSpeed(speed);
+              setGasEstimate(estimate);
+            }}
+          />
+          {gasEstimate && (
+            <div className="flex justify-between text-xs" style={{ color: "var(--muted)" }}>
+              <span>Est. gas fee</span>
+              <span>
+                {gasEstimate.feeUsd > 0
+                  ? `≈ $${gasEstimate.feeUsd < 0.01 ? "<0.01" : gasEstimate.feeUsd.toFixed(3)}`
+                  : `${parseFloat(gasEstimate.feeEth).toFixed(6)} MNT`}
+              </span>
+            </div>
+          )}
           <button
             disabled={!amount || market.status !== "open"}
             className="w-full py-2.5 rounded-lg text-sm font-semibold text-white transition-opacity disabled:opacity-40"

--- a/Frontend/app/markets/create/page.tsx
+++ b/Frontend/app/markets/create/page.tsx
@@ -1,9 +1,20 @@
 import CreateMarketForm from "../../../components/market/CreateMarketForm";
+import dynamic from "next/dynamic";
+
+const GasEstimator = dynamic(
+  () => import("../../../components/gas/GasEstimator"),
+  { ssr: false }
+);
 
 export default function CreateMarketPage() {
   return (
-    <main className="max-w-2xl mx-auto px-4 py-10">
+    <main className="max-w-2xl mx-auto px-4 py-10 space-y-4">
       <CreateMarketForm />
+      <GasEstimator
+        gasLimit={300_000n}
+        defaultSpeed="standard"
+        className="max-w-xl mx-auto"
+      />
     </main>
   );
 }

--- a/Frontend/components/gas/GasEstimator.tsx
+++ b/Frontend/components/gas/GasEstimator.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { createPublicClient, http, formatGwei, formatEther } from "viem";
+import { mantle } from "viem/chains";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type GasSpeed = "slow" | "standard" | "fast";
+
+export interface GasEstimate {
+  /** Gas price in wei */
+  gasPrice: bigint;
+  /** Estimated fee in ETH (as a formatted string) */
+  feeEth: string;
+  /** Estimated fee in USD */
+  feeUsd: number;
+  /** Estimated confirmation time label */
+  time: string;
+}
+
+export interface GasEstimates {
+  slow: GasEstimate;
+  standard: GasEstimate;
+  fast: GasEstimate;
+  /** Block number these estimates were fetched at */
+  blockNumber: bigint;
+  /** Timestamp of last fetch */
+  fetchedAt: number;
+}
+
+export interface GasEstimatorProps {
+  /**
+   * Gas units the transaction will consume.
+   * Defaults to 150_000 (typical ERC-20 interaction / market trade).
+   */
+  gasLimit?: bigint;
+  /**
+   * Called when the user selects a speed tier.
+   * Receives the selected speed and its estimate.
+   */
+  onSelect?: (speed: GasSpeed, estimate: GasEstimate) => void;
+  /** Pre-selected speed tier. Defaults to "standard". */
+  defaultSpeed?: GasSpeed;
+  /** Refresh interval in ms. Defaults to 12 000 (≈ 1 Mantle block). */
+  refreshInterval?: number;
+  /** Whether to show the component in compact (single-row) mode */
+  compact?: boolean;
+  className?: string;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_GAS_LIMIT = 150_000n;
+const DEFAULT_REFRESH_MS = 12_000;
+
+/** Speed multipliers applied to the base fee to derive tiers */
+const SPEED_MULTIPLIERS: Record<GasSpeed, number> = {
+  slow: 0.85,
+  standard: 1.0,
+  fast: 1.25,
+};
+
+const SPEED_LABELS: Record<GasSpeed, string> = {
+  slow: "Slow",
+  standard: "Standard",
+  fast: "Fast",
+};
+
+const SPEED_TIMES: Record<GasSpeed, string> = {
+  slow: "~30s",
+  standard: "~12s",
+  fast: "~6s",
+};
+
+const SPEED_COLORS: Record<GasSpeed, string> = {
+  slow: "#f59e0b",
+  standard: "#3b82f6",
+  fast: "#22c55e",
+};
+
+// ─── Viem client (Mantle) ─────────────────────────────────────────────────────
+
+const publicClient = createPublicClient({
+  chain: mantle,
+  transport: http(),
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch MNT/USD price from CoinGecko public API.
+ * Falls back to 0 on error so the component still renders without USD.
+ */
+async function fetchMntUsdPrice(): Promise<number> {
+  try {
+    const res = await fetch(
+      "https://api.coingecko.com/api/v3/simple/price?ids=mantle&vs_currencies=usd",
+      { next: { revalidate: 60 } }
+    );
+    if (!res.ok) return 0;
+    const json = await res.json();
+    return json?.mantle?.usd ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+function applyMultiplier(base: bigint, multiplier: number): bigint {
+  // Use integer arithmetic: multiply by 1000, then divide
+  return (base * BigInt(Math.round(multiplier * 1000))) / 1000n;
+}
+
+function buildEstimate(
+  gasPrice: bigint,
+  gasLimit: bigint,
+  mntUsd: number,
+  speed: GasSpeed
+): GasEstimate {
+  const feeWei = gasPrice * gasLimit;
+  const feeEth = formatEther(feeWei);
+  const feeUsd = mntUsd > 0 ? parseFloat(feeEth) * mntUsd : 0;
+  return {
+    gasPrice,
+    feeEth,
+    feeUsd,
+    time: SPEED_TIMES[speed],
+  };
+}
+
+async function fetchEstimates(gasLimit: bigint): Promise<GasEstimates> {
+  const [feeData, blockNumber, mntUsd] = await Promise.all([
+    publicClient.estimateFeesPerGas(),
+    publicClient.getBlockNumber(),
+    fetchMntUsdPrice(),
+  ]);
+
+  // Use maxFeePerGas if EIP-1559, otherwise fall back to gasPrice
+  const baseGasPrice =
+    feeData.maxFeePerGas ?? feeData.gasPrice ?? 1_000_000n;
+
+  const speeds: GasSpeed[] = ["slow", "standard", "fast"];
+  const estimates = Object.fromEntries(
+    speeds.map((speed) => {
+      const gasPrice = applyMultiplier(baseGasPrice, SPEED_MULTIPLIERS[speed]);
+      return [speed, buildEstimate(gasPrice, gasLimit, mntUsd, speed)];
+    })
+  ) as Record<GasSpeed, GasEstimate>;
+
+  return {
+    ...estimates,
+    blockNumber,
+    fetchedAt: Date.now(),
+  };
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function SpeedIcon({ speed }: { speed: GasSpeed }) {
+  const color = SPEED_COLORS[speed];
+  if (speed === "slow") {
+    return (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <circle cx="8" cy="8" r="6" stroke={color} strokeWidth="1.5" />
+        <path d="M8 5v3l2 1.5" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  if (speed === "standard") {
+    return (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path d="M3 8h10M9 5l4 3-4 3" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
+  // fast
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M2 8h8M7 5l4 3-4 3" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M10 8h4" stroke={color} strokeWidth="1.5" strokeLinecap="round" opacity="0.5" />
+    </svg>
+  );
+}
+
+function RefreshIcon({ spinning }: { spinning: boolean }) {
+  return (
+    <motion.svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+      animate={spinning ? { rotate: 360 } : { rotate: 0 }}
+      transition={spinning ? { duration: 0.8, repeat: Infinity, ease: "linear" } : {}}
+    >
+      <path
+        d="M13.5 8A5.5 5.5 0 1 1 8 2.5c1.8 0 3.4.87 4.4 2.2"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path d="M12 2v3h-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </motion.svg>
+  );
+}
+
+function GasSkeletonRow() {
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg"
+      style={{ background: "var(--background)", border: "1px solid var(--border)" }}>
+      <div className="flex items-center gap-2">
+        <div className="w-3.5 h-3.5 rounded-full animate-pulse" style={{ background: "var(--border)" }} />
+        <div className="w-14 h-3 rounded animate-pulse" style={{ background: "var(--border)" }} />
+      </div>
+      <div className="flex items-center gap-3">
+        <div className="w-20 h-3 rounded animate-pulse" style={{ background: "var(--border)" }} />
+        <div className="w-12 h-3 rounded animate-pulse" style={{ background: "var(--border)" }} />
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function GasEstimator({
+  gasLimit = DEFAULT_GAS_LIMIT,
+  onSelect,
+  defaultSpeed = "standard",
+  refreshInterval = DEFAULT_REFRESH_MS,
+  compact = false,
+  className = "",
+}: GasEstimatorProps) {
+  const [estimates, setEstimates] = useState<GasEstimates | null>(null);
+  const [selected, setSelected] = useState<GasSpeed>(defaultSpeed);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [secondsAgo, setSecondsAgo] = useState(0);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const load = useCallback(
+    async (isManual = false) => {
+      if (isManual) setRefreshing(true);
+      setError(null);
+      try {
+        const data = await fetchEstimates(gasLimit);
+        setEstimates(data);
+        setSecondsAgo(0);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to fetch gas estimates");
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [gasLimit]
+  );
+
+  // Initial load + auto-refresh
+  useEffect(() => {
+    load();
+    intervalRef.current = setInterval(() => load(), refreshInterval);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [load, refreshInterval]);
+
+  // "X seconds ago" ticker
+  useEffect(() => {
+    tickRef.current = setInterval(() => {
+      setSecondsAgo((s) => s + 1);
+    }, 1000);
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+    };
+  }, []);
+
+  function handleSelect(speed: GasSpeed) {
+    setSelected(speed);
+    if (estimates && onSelect) {
+      onSelect(speed, estimates[speed]);
+    }
+  }
+
+  // Notify parent when estimates update (keep selected in sync)
+  useEffect(() => {
+    if (estimates && onSelect) {
+      onSelect(selected, estimates[selected]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [estimates]);
+
+  const speeds: GasSpeed[] = ["slow", "standard", "fast"];
+
+  // ── Compact mode ────────────────────────────────────────────────────────────
+  if (compact) {
+    return (
+      <div
+        className={`flex items-center gap-2 flex-wrap ${className}`}
+        aria-label="Gas fee estimate"
+      >
+        <span className="text-xs" style={{ color: "var(--muted)" }}>
+          Gas:
+        </span>
+        {loading ? (
+          <div className="w-24 h-3 rounded animate-pulse" style={{ background: "var(--border)" }} />
+        ) : error ? (
+          <span className="text-xs" style={{ color: "#ef4444" }}>Unavailable</span>
+        ) : estimates ? (
+          <>
+            {speeds.map((speed) => {
+              const est = estimates[speed];
+              const isSelected = selected === speed;
+              return (
+                <button
+                  key={speed}
+                  onClick={() => handleSelect(speed)}
+                  className="flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium transition-all"
+                  style={{
+                    background: isSelected ? SPEED_COLORS[speed] + "22" : "transparent",
+                    border: `1px solid ${isSelected ? SPEED_COLORS[speed] + "66" : "var(--border)"}`,
+                    color: isSelected ? SPEED_COLORS[speed] : "var(--muted)",
+                  }}
+                  aria-pressed={isSelected}
+                  aria-label={`${SPEED_LABELS[speed]} gas: ${est.feeEth} MNT`}
+                >
+                  <SpeedIcon speed={speed} />
+                  {est.feeUsd > 0
+                    ? `$${est.feeUsd < 0.01 ? "<0.01" : est.feeUsd.toFixed(2)}`
+                    : `${parseFloat(est.feeEth).toFixed(6)} MNT`}
+                </button>
+              );
+            })}
+          </>
+        ) : null}
+      </div>
+    );
+  }
+
+  // ── Full mode ───────────────────────────────────────────────────────────────
+  return (
+    <div
+      className={`rounded-xl overflow-hidden ${className}`}
+      style={{ background: "var(--card)", border: "1px solid var(--border)" }}
+      aria-label="Gas fee estimator"
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-4 py-3"
+        style={{ borderBottom: "1px solid var(--border)" }}
+      >
+        <div className="flex items-center gap-2">
+          {/* Gas pump icon */}
+          <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <rect x="2" y="4" width="8" height="10" rx="1.5" stroke="var(--muted)" strokeWidth="1.4" />
+            <path d="M6 4V2h2v2" stroke="var(--muted)" strokeWidth="1.4" strokeLinecap="round" />
+            <path d="M10 6h2a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-2" stroke="var(--muted)" strokeWidth="1.4" strokeLinecap="round" />
+            <path d="M4 9h4" stroke="var(--muted)" strokeWidth="1.4" strokeLinecap="round" />
+          </svg>
+          <span className="text-sm font-semibold" style={{ color: "var(--foreground)" }}>
+            Gas Estimate
+          </span>
+          {estimates && (
+            <span className="text-xs" style={{ color: "var(--muted)" }}>
+              · {secondsAgo < 5 ? "just now" : `${secondsAgo}s ago`}
+            </span>
+          )}
+        </div>
+
+        <button
+          onClick={() => load(true)}
+          disabled={refreshing || loading}
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-opacity hover:opacity-70 disabled:opacity-40"
+          style={{ color: "var(--muted)", border: "1px solid var(--border)" }}
+          aria-label="Refresh gas estimates"
+        >
+          <RefreshIcon spinning={refreshing} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="p-3 space-y-2">
+        {/* Gas limit info */}
+        <div className="flex items-center justify-between px-1 mb-1">
+          <span className="text-xs" style={{ color: "var(--muted)" }}>
+            Gas limit
+          </span>
+          <span className="text-xs font-mono" style={{ color: "var(--foreground)" }}>
+            {gasLimit.toLocaleString()} units
+          </span>
+        </div>
+
+        {/* Speed rows */}
+        {loading ? (
+          <>
+            <GasSkeletonRow />
+            <GasSkeletonRow />
+            <GasSkeletonRow />
+          </>
+        ) : error ? (
+          <div
+            className="rounded-lg px-4 py-3 text-sm"
+            style={{ background: "#ef444418", border: "1px solid #ef444444", color: "#ef4444" }}
+          >
+            <p className="font-medium">Could not fetch gas prices</p>
+            <p className="text-xs mt-0.5" style={{ color: "#ef4444aa" }}>{error}</p>
+          </div>
+        ) : estimates ? (
+          <AnimatePresence initial={false}>
+            {speeds.map((speed) => {
+              const est = estimates[speed];
+              const isSelected = selected === speed;
+              const color = SPEED_COLORS[speed];
+
+              return (
+                <motion.button
+                  key={speed}
+                  layout
+                  onClick={() => handleSelect(speed)}
+                  className="w-full flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-left transition-all"
+                  style={{
+                    background: isSelected ? color + "14" : "var(--background)",
+                    border: `1px solid ${isSelected ? color + "55" : "var(--border)"}`,
+                    outline: "none",
+                  }}
+                  whileTap={{ scale: 0.985 }}
+                  aria-pressed={isSelected}
+                  aria-label={`${SPEED_LABELS[speed]}: ${est.feeEth} MNT, ${est.time}`}
+                >
+                  {/* Left: icon + label + time */}
+                  <div className="flex items-center gap-2 min-w-0">
+                    <SpeedIcon speed={speed} />
+                    <div>
+                      <p
+                        className="text-xs font-semibold leading-none"
+                        style={{ color: isSelected ? color : "var(--foreground)" }}
+                      >
+                        {SPEED_LABELS[speed]}
+                      </p>
+                      <p className="text-xs mt-0.5" style={{ color: "var(--muted)" }}>
+                        {est.time}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Right: fee amounts */}
+                  <div className="text-right shrink-0">
+                    <AnimatePresence mode="wait">
+                      <motion.p
+                        key={est.feeEth}
+                        initial={{ opacity: 0, y: -4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: 4 }}
+                        transition={{ duration: 0.2 }}
+                        className="text-xs font-semibold font-mono leading-none"
+                        style={{ color: isSelected ? color : "var(--foreground)" }}
+                      >
+                        {parseFloat(est.feeEth).toFixed(6)} MNT
+                      </motion.p>
+                    </AnimatePresence>
+                    {est.feeUsd > 0 && (
+                      <AnimatePresence mode="wait">
+                        <motion.p
+                          key={est.feeUsd}
+                          initial={{ opacity: 0 }}
+                          animate={{ opacity: 1 }}
+                          exit={{ opacity: 0 }}
+                          transition={{ duration: 0.2 }}
+                          className="text-xs mt-0.5"
+                          style={{ color: "var(--muted)" }}
+                        >
+                          ≈ ${est.feeUsd < 0.01 ? "<$0.01" : `$${est.feeUsd.toFixed(3)}`}
+                        </motion.p>
+                      </AnimatePresence>
+                    )}
+                    <p className="text-xs mt-0.5" style={{ color: "var(--muted)" }}>
+                      {formatGwei(est.gasPrice)} Gwei
+                    </p>
+                  </div>
+
+                  {/* Selected checkmark */}
+                  {isSelected && (
+                    <motion.div
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center"
+                      style={{ background: color }}
+                    >
+                      <svg width="8" height="8" viewBox="0 0 8 8" fill="none" aria-hidden="true">
+                        <path d="M1.5 4l2 2 3-3" stroke="#fff" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </motion.div>
+                  )}
+                </motion.button>
+              );
+            })}
+          </AnimatePresence>
+        ) : null}
+
+        {/* Footer: block number */}
+        {estimates && !error && (
+          <div className="flex items-center justify-between pt-1 px-1">
+            <span className="text-xs" style={{ color: "var(--muted)" }}>
+              Block #{estimates.blockNumber.toString()}
+            </span>
+            <span className="text-xs" style={{ color: "var(--muted)" }}>
+              Auto-refreshes every {refreshInterval / 1000}s
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/Frontend/hooks/useToast.ts
+++ b/Frontend/hooks/useToast.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ToastType = "success" | "error" | "warning" | "info";
+
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface Toast {
+  id: string;
+  type: ToastType;
+  /** Bold heading line */
+  title?: string;
+  /** Secondary body text */
+  message?: string;
+  /**
+   * Auto-dismiss delay in ms.
+   * Pass 0 to keep until manually dismissed.
+   * Default: 5000 (errors default to 7000)
+   */
+  duration?: number;
+  /** Optional inline action button */
+  action?: ToastAction;
+}
+
+export type ToastInput = Omit<Toast, "id">;
+
+// ─── Context value shape ──────────────────────────────────────────────────────
+
+export interface ToastContextValue {
+  toasts: Toast[];
+  /** Add a toast and return its generated id */
+  toast: (input: ToastInput) => string;
+  /** Dismiss a specific toast by id */
+  dismiss: (id: string) => void;
+  /** Dismiss all toasts */
+  dismissAll: () => void;
+  // Convenience helpers
+  success: (title: string, message?: string, opts?: Partial<ToastInput>) => string;
+  error: (title: string, message?: string, opts?: Partial<ToastInput>) => string;
+  warning: (title: string, message?: string, opts?: Partial<ToastInput>) => string;
+  info: (title: string, message?: string, opts?: Partial<ToastInput>) => string;
+}
+
+// ─── Context (default is a no-op stub) ───────────────────────────────────────
+
+export const ToastContext = createContext<ToastContextValue>({
+  toasts: [],
+  toast: () => "",
+  dismiss: () => {},
+  dismissAll: () => {},
+  success: () => "",
+  error: () => "",
+  warning: () => "",
+  info: () => "",
+});
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useToast(): ToastContextValue {
+  return useContext(ToastContext);
+}


### PR DESCRIPTION
close #13 

4 files created/modified:

useToast.ts
 — the context definition and useToast hook. Exports the Toast types, ToastContext, and the hook itself. Kept as a plain .ts file with no JSX.

ToastProvider.tsx
 — the state layer. Uses useReducer to manage the toast queue (capped at 5), exposes toast(), dismiss(), dismissAll(), and four convenience helpers: success(), error(), warning(), info(). Renders <ToastContainer /> as a sibling to children so it's always mounted.

Toast.tsx
 — the visual layer. ToastContainer is a fixed bottom-right portal. Each ToastItem has:

Spring-animated enter/exit via framer-motion
Color-coded left border + icon per type (green/red/amber/blue)
A shrinking progress bar that pauses on hover
Manual dismiss button
Optional action button that fires a callback then auto-dismisses
layout.tsx
 — <ToastProvider> wrapped around the app so toasts are available everywhere.

Usage anywhere in the app:

const { success, error, warning, info } = useToast();

success("Trade placed", "Your position has been submitted.");
error("Transaction failed", "Insufficient balance.", { duration: 0 }); // persistent
warning("Market closing soon", "2 hours remaining.");
info("Price updated", undefined, {
  action: { label: "View chart", onClick: () => router.push("/markets/1") }
});
close #12 

GasEstimator.tsx
 — the main component. Key design decisions:

Data fetching — uses viem's createPublicClient against Mantle to call estimateFeesPerGas() (EIP-1559 aware, falls back to legacy gasPrice) and getBlockNumber() in parallel. MNT/USD price comes from CoinGecko's free public API with a graceful fallback to 0 if unavailable.
Three speed tiers — slow (0.85×), standard (1.0×), fast (1.25×) applied to the base fee using integer arithmetic to avoid BigInt/float mixing issues.
Auto-refresh — polls every 12s (one Mantle block) with a "seconds ago" ticker. Pauses the timer correctly on manual refresh.
Two render modes — compact prop renders an inline pill row for tight spaces (trading panel); default renders a full card with a progress bar, block number, and animated value transitions via framer-motion.
onSelect callback — fires whenever the user picks a tier or estimates update, so parent components can pass the selected gas price into the actual transaction.
Frontend/app/markets/[id]/page.tsx — compact gas estimator embedded in the "Place Trade" panel, with a summary row showing the selected fee below the shares estimate.

page.tsx
 — full gas estimator card rendered below the create market form, using gasLimit={300_000n} appropriate for a contract deployment interaction.