### PR TITLE
feat: add payout calculation logic (#65)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
 [submodule "Contracts/lib/prb-math"]
 	path = Contracts/lib/prb-math
-	url = https://github.com/paulrberg/prb-math
+	url = https://github.com/PaulRBerg/prb-math

--- a/Contracts/contracts/Payout.sol
+++ b/Contracts/contracts/Payout.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { UD60x18, ud, unwrap } from "@prb/math/src/UD60x18.sol";
+import "../src/ERC20Token.sol";
+
+/// @title Payout – market payout calculation and claim processing
+/// @notice Supports three payout models:
+///         WINNER_TAKE_ALL  – each winning share redeems 1 collateral token (standard binary market)
+///         PROPORTIONAL     – winning-side pool is distributed pro-rata to share holders
+///         SCALAR           – payout per share scales linearly between a floor and ceiling price
+contract Payout {
+    // ── Types ─────────────────────────────────────────────────────────────────
+
+    enum PayoutModel { WINNER_TAKE_ALL, PROPORTIONAL, SCALAR }
+    enum ClaimStatus { NONE, PENDING, CLAIMED }
+
+    struct MarketPayout {
+        PayoutModel model;
+        bool        resolved;
+        uint256     winningOutcome;
+        uint256     totalPool;        // total collateral held (WAD)
+        uint256     winningPool;      // collateral staked on winning outcome (WAD)
+        /// @dev For SCALAR: settlement price in WAD (must be in [floorPrice, ceilPrice])
+        uint256     settlementPrice;
+        uint256     floorPrice;       // WAD – minimum payout per share for SCALAR
+        uint256     ceilPrice;        // WAD – maximum payout per share for SCALAR
+    }
+
+    // ── State ─────────────────────────────────────────────────────────────────
+
+    ERC20Token public immutable collateral;
+    address    public owner;
+
+    /// marketId => MarketPayout
+    mapping(uint256 => MarketPayout) public markets;
+    /// marketId => user => outcome => shares (WAD)
+    mapping(uint256 => mapping(address => mapping(uint256 => uint256))) public shares;
+    /// marketId => outcome => total shares outstanding (WAD)
+    mapping(uint256 => mapping(uint256 => uint256)) public totalShares;
+    /// marketId => user => ClaimStatus
+    mapping(uint256 => mapping(address => ClaimStatus)) public claimStatus;
+
+    // ── Events ────────────────────────────────────────────────────────────────
+
+    event MarketRegistered(uint256 indexed marketId, PayoutModel model);
+    event MarketResolved(uint256 indexed marketId, uint256 winningOutcome, uint256 settlementPrice);
+    event SharesRecorded(uint256 indexed marketId, address indexed user, uint256 outcome, uint256 amount);
+    event PayoutClaimed(uint256 indexed marketId, address indexed user, uint256 amount);
+
+    // ── Errors ────────────────────────────────────────────────────────────────
+
+    error Unauthorized();
+    error AlreadyRegistered();
+    error AlreadyResolved();
+    error NotResolved();
+    error AlreadyClaimed();
+    error NothingToClaim();
+    error InvalidPrice();
+
+    // ── Constructor ───────────────────────────────────────────────────────────
+
+    constructor(address _collateral) {
+        collateral = ERC20Token(_collateral);
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert Unauthorized();
+        _;
+    }
+
+    // ── Market setup ──────────────────────────────────────────────────────────
+
+    /// @notice Register a new market with a chosen payout model.
+    /// @param floorPrice  Only used for SCALAR; ignored otherwise (pass 0).
+    /// @param ceilPrice   Only used for SCALAR; ignored otherwise (pass 0).
+    function registerMarket(
+        uint256    marketId,
+        PayoutModel model,
+        uint256    floorPrice,
+        uint256    ceilPrice
+    ) external onlyOwner {
+        if (markets[marketId].totalPool != 0 || markets[marketId].resolved) revert AlreadyRegistered();
+        if (model == PayoutModel.SCALAR) {
+            if (floorPrice >= ceilPrice) revert InvalidPrice();
+        }
+        markets[marketId] = MarketPayout({
+            model:           model,
+            resolved:        false,
+            winningOutcome:  0,
+            totalPool:       0,
+            winningPool:     0,
+            settlementPrice: 0,
+            floorPrice:      floorPrice,
+            ceilPrice:       ceilPrice
+        });
+        emit MarketRegistered(marketId, model);
+    }
+
+    /// @notice Record shares purchased by a user (called by the trading layer).
+    function recordShares(uint256 marketId, address user, uint256 outcome, uint256 amount) external onlyOwner {
+        shares[marketId][user][outcome]  += amount;
+        totalShares[marketId][outcome]   += amount;
+        markets[marketId].totalPool      += amount; // 1 share costs 1 collateral in WINNER_TAKE_ALL
+        emit SharesRecorded(marketId, user, outcome, amount);
+    }
+
+    /// @notice Resolve a market.
+    /// @param settlementPrice  For SCALAR: final price in WAD within [floor, ceil].
+    ///                         For other models: ignored (pass 0).
+    function resolveMarket(
+        uint256 marketId,
+        uint256 winningOutcome,
+        uint256 settlementPrice
+    ) external onlyOwner {
+        MarketPayout storage m = markets[marketId];
+        if (m.resolved) revert AlreadyResolved();
+
+        m.resolved       = true;
+        m.winningOutcome = winningOutcome;
+        m.winningPool    = totalShares[marketId][winningOutcome];
+
+        if (m.model == PayoutModel.SCALAR) {
+            if (settlementPrice < m.floorPrice || settlementPrice > m.ceilPrice) revert InvalidPrice();
+            m.settlementPrice = settlementPrice;
+        }
+
+        emit MarketResolved(marketId, winningOutcome, settlementPrice);
+    }
+
+    // ── Payout calculation ────────────────────────────────────────────────────
+
+    /// @notice Calculate the payout owed to `user` for `marketId`.
+    /// @dev    Pure view – does not transfer tokens.
+    function calculatePayout(uint256 marketId, address user) public view returns (uint256 payout) {
+        MarketPayout storage m = markets[marketId];
+        if (!m.resolved) revert NotResolved();
+
+        uint256 userShares = shares[marketId][user][m.winningOutcome];
+        if (userShares == 0) return 0;
+
+        if (m.model == PayoutModel.WINNER_TAKE_ALL) {
+            // 1 winning share → 1 collateral token
+            payout = userShares;
+
+        } else if (m.model == PayoutModel.PROPORTIONAL) {
+            // user's share of the winning pool × total pool
+            // payout = (userShares / winningPool) * totalPool
+            UD60x18 ratio = ud(userShares).div(ud(m.winningPool));
+            payout = unwrap(ratio.mul(ud(m.totalPool)));
+
+        } else {
+            // SCALAR: payout per share scales linearly between floor and ceil
+            // payoutPerShare = floor + (settlement - floor) * (ceil - floor) / (ceil - floor)
+            //                = settlementPrice  (already clamped to [floor, ceil])
+            // payout = userShares * settlementPrice / WAD
+            UD60x18 payoutPerShare = ud(m.settlementPrice);
+            payout = unwrap(ud(userShares).mul(payoutPerShare));
+        }
+    }
+
+    // ── Claim processing ──────────────────────────────────────────────────────
+
+    /// @notice Claim payout for the caller.
+    function claim(uint256 marketId) external {
+        if (claimStatus[marketId][msg.sender] == ClaimStatus.CLAIMED) revert AlreadyClaimed();
+
+        uint256 amount = calculatePayout(marketId, msg.sender);
+        if (amount == 0) revert NothingToClaim();
+
+        claimStatus[marketId][msg.sender] = ClaimStatus.CLAIMED;
+        collateral.transfer(msg.sender, amount);
+
+        emit PayoutClaimed(marketId, msg.sender, amount);
+    }
+
+    /// @notice Check claim status for a user.
+    function getClaimStatus(uint256 marketId, address user) external view returns (ClaimStatus) {
+        return claimStatus[marketId][user];
+    }
+}

--- a/Contracts/foundry.lock
+++ b/Contracts/foundry.lock
@@ -1,4 +1,16 @@
 {
+  "lib/forge-std": {
+    "rev": "8987040ede9553cea20c95ad40d0455930f9c8e0"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "5fd1781b1454fd1ef8e722282f86f9293cacf256"
+  },
+  "lib/prb-math": {
+    "tag": {
+      "name": "v4.1.1",
+      "rev": "b51e8631ed28d3cc917c491dd47cd6c3ff652edc"
+    }
+  },
   "lib\\forge-std": {
     "tag": {
       "name": "v1.16.0",

--- a/Contracts/test/Payout.t.sol
+++ b/Contracts/test/Payout.t.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/Payout.sol";
+import "../src/ERC20Token.sol";
+
+contract PayoutTest is Test {
+    ERC20Token token;
+    Payout     payout;
+
+    address alice = address(0xA);
+    address bob   = address(0xB);
+
+    uint256 constant WAD = 1e18;
+
+    function setUp() public {
+        token  = new ERC20Token(0);
+        payout = new Payout(address(token));
+        token.addMinter(address(this));
+        // Fund the payout contract so it can transfer on claims
+        token.mint(address(payout), 10_000 * WAD);
+    }
+
+    // ── WINNER_TAKE_ALL ───────────────────────────────────────────────────────
+
+    function testWinnerTakeAll_CorrectPayout() public {
+        payout.registerMarket(1, Payout.PayoutModel.WINNER_TAKE_ALL, 0, 0);
+        payout.recordShares(1, alice, 0, 100 * WAD); // alice: 100 YES
+        payout.recordShares(1, bob,   1, 200 * WAD); // bob:   200 NO
+        payout.resolveMarket(1, 0, 0);               // YES wins
+
+        assertEq(payout.calculatePayout(1, alice), 100 * WAD);
+        assertEq(payout.calculatePayout(1, bob),   0);
+    }
+
+    function testWinnerTakeAll_Claim() public {
+        payout.registerMarket(2, Payout.PayoutModel.WINNER_TAKE_ALL, 0, 0);
+        payout.recordShares(2, alice, 0, 50 * WAD);
+        payout.resolveMarket(2, 0, 0);
+
+        uint256 before = token.balanceOf(alice);
+        vm.prank(alice);
+        payout.claim(2);
+        assertEq(token.balanceOf(alice), before + 50 * WAD);
+        assertEq(uint8(payout.getClaimStatus(2, alice)), uint8(Payout.ClaimStatus.CLAIMED));
+    }
+
+    function testWinnerTakeAll_DoubleClaim_Reverts() public {
+        payout.registerMarket(3, Payout.PayoutModel.WINNER_TAKE_ALL, 0, 0);
+        payout.recordShares(3, alice, 0, 10 * WAD);
+        payout.resolveMarket(3, 0, 0);
+
+        vm.startPrank(alice);
+        payout.claim(3);
+        vm.expectRevert(Payout.AlreadyClaimed.selector);
+        payout.claim(3);
+        vm.stopPrank();
+    }
+
+    function testWinnerTakeAll_NothingToClaim_Reverts() public {
+        payout.registerMarket(4, Payout.PayoutModel.WINNER_TAKE_ALL, 0, 0);
+        payout.recordShares(4, alice, 1, 10 * WAD); // alice holds NO
+        payout.resolveMarket(4, 0, 0);              // YES wins
+
+        vm.prank(alice);
+        vm.expectRevert(Payout.NothingToClaim.selector);
+        payout.claim(4);
+    }
+
+    // ── PROPORTIONAL ─────────────────────────────────────────────────────────
+
+    function testProportional_EqualSplit() public {
+        payout.registerMarket(10, Payout.PayoutModel.PROPORTIONAL, 0, 0);
+        payout.recordShares(10, alice, 0, 100 * WAD);
+        payout.recordShares(10, bob,   0, 100 * WAD);
+        payout.recordShares(10, alice, 1, 200 * WAD); // losing side
+        payout.resolveMarket(10, 0, 0);
+
+        // totalPool = 400 WAD, winningPool = 200 WAD
+        // alice: 100/200 * 400 = 200 WAD
+        // bob:   100/200 * 400 = 200 WAD
+        assertApproxEqAbs(payout.calculatePayout(10, alice), 200 * WAD, 1e9);
+        assertApproxEqAbs(payout.calculatePayout(10, bob),   200 * WAD, 1e9);
+    }
+
+    function testProportional_UnequalSplit() public {
+        payout.registerMarket(11, Payout.PayoutModel.PROPORTIONAL, 0, 0);
+        payout.recordShares(11, alice, 0, 300 * WAD); // 75% of winning pool
+        payout.recordShares(11, bob,   0, 100 * WAD); // 25% of winning pool
+        payout.recordShares(11, bob,   1, 400 * WAD); // losing side
+        payout.resolveMarket(11, 0, 0);
+
+        // totalPool = 800 WAD, winningPool = 400 WAD
+        // alice: 300/400 * 800 = 600 WAD
+        // bob:   100/400 * 800 = 200 WAD
+        assertApproxEqAbs(payout.calculatePayout(11, alice), 600 * WAD, 1e9);
+        assertApproxEqAbs(payout.calculatePayout(11, bob),   200 * WAD, 1e9);
+    }
+
+    // ── SCALAR ────────────────────────────────────────────────────────────────
+
+    function testScalar_AtFloor() public {
+        uint256 floor = 0.2e18;
+        uint256 ceil  = 0.8e18;
+        payout.registerMarket(20, Payout.PayoutModel.SCALAR, floor, ceil);
+        payout.recordShares(20, alice, 0, 100 * WAD);
+        payout.resolveMarket(20, 0, floor); // settles at floor
+
+        // payout = 100 * 0.2 = 20 WAD
+        assertApproxEqAbs(payout.calculatePayout(20, alice), 20 * WAD, 1e9);
+    }
+
+    function testScalar_AtCeil() public {
+        uint256 floor = 0.2e18;
+        uint256 ceil  = 0.8e18;
+        payout.registerMarket(21, Payout.PayoutModel.SCALAR, floor, ceil);
+        payout.recordShares(21, alice, 0, 100 * WAD);
+        payout.resolveMarket(21, 0, ceil); // settles at ceil
+
+        // payout = 100 * 0.8 = 80 WAD
+        assertApproxEqAbs(payout.calculatePayout(21, alice), 80 * WAD, 1e9);
+    }
+
+    function testScalar_Midpoint() public {
+        uint256 floor = 0.2e18;
+        uint256 ceil  = 0.8e18;
+        uint256 mid   = 0.5e18;
+        payout.registerMarket(22, Payout.PayoutModel.SCALAR, floor, ceil);
+        payout.recordShares(22, alice, 0, 100 * WAD);
+        payout.resolveMarket(22, 0, mid);
+
+        // payout = 100 * 0.5 = 50 WAD
+        assertApproxEqAbs(payout.calculatePayout(22, alice), 50 * WAD, 1e9);
+    }
+
+    function testScalar_OutOfRange_Reverts() public {
+        payout.registerMarket(23, Payout.PayoutModel.SCALAR, 0.2e18, 0.8e18);
+        vm.expectRevert(Payout.InvalidPrice.selector);
+        payout.resolveMarket(23, 0, 0.9e18); // above ceil
+    }
+
+    // ── Guard rails ───────────────────────────────────────────────────────────
+
+    function testClaimBeforeResolution_Reverts() public {
+        payout.registerMarket(30, Payout.PayoutModel.WINNER_TAKE_ALL, 0, 0);
+        payout.recordShares(30, alice, 0, 10 * WAD);
+        vm.prank(alice);
+        vm.expectRevert(Payout.NotResolved.selector);
+        payout.claim(30);
+    }
+
+    function testDoubleResolve_Reverts() public {
+        payout.registerMarket(31, Payout.PayoutModel.WINNER_TAKE_ALL, 0, 0);
+        payout.resolveMarket(31, 0, 0);
+        vm.expectRevert(Payout.AlreadyResolved.selector);
+        payout.resolveMarket(31, 0, 0);
+    }
+
+    function testUnauthorized_Reverts() public {
+        vm.prank(alice);
+        vm.expectRevert(Payout.Unauthorized.selector);
+        payout.registerMarket(99, Payout.PayoutModel.WINNER_TAKE_ALL, 0, 0);
+    }
+
+    // ── Fuzz ─────────────────────────────────────────────────────────────────
+
+    function testFuzz_WinnerTakeAll(uint128 aliceShares, uint128 bobShares) public {
+        vm.assume(aliceShares > 0 && bobShares > 0);
+        uint256 a = uint256(aliceShares);
+        uint256 b = uint256(bobShares);
+
+        // Ensure payout contract has enough balance
+        token.mint(address(payout), a + b);
+
+        payout.registerMarket(50, Payout.PayoutModel.WINNER_TAKE_ALL, 0, 0);
+        payout.recordShares(50, alice, 0, a);
+        payout.recordShares(50, bob,   1, b);
+        payout.resolveMarket(50, 0, 0);
+
+        assertEq(payout.calculatePayout(50, alice), a);
+        assertEq(payout.calculatePayout(50, bob),   0);
+    }
+}


### PR DESCRIPTION
Closes #65

## Summary
Implements `Payout.sol` and `test/Payout.t.sol` with full payout calculation logic using PRBMath UD60x18.

## New Files
- `Contracts/contracts/Payout.sol`
- `Contracts/test/Payout.t.sol`

## Payout Models
| Model | Logic |
|-------|-------|
| `WINNER_TAKE_ALL` | 1 winning share → 1 collateral token |
| `PROPORTIONAL` | `(userShares / winningPool) × totalPool` via UD60x18 |
| `SCALAR` | `userShares × settlementPrice` where price ∈ [floor, ceil] |

## Features
- **resolveMarket()**: sets winning outcome; validates settlement price is within [floor, ceil] for SCALAR
- **calculatePayout()**: pure view, returns owed amount without side effects
- **claim()**: atomic transfer with double-claim guard (`AlreadyClaimed` revert)
- **claimStatus**: per-user per-market enum tracking `NONE / PENDING / CLAIMED`
- **PRBMath v4.1.1**: UD60x18 used for proportional and scalar arithmetic

## Tests (14 passing, 0 failing)
- WINNER_TAKE_ALL: correct payout, claim transfer, double-claim revert, nothing-to-claim revert
- PROPORTIONAL: equal split, unequal split
- SCALAR: at floor, at ceiling, midpoint, out-of-range revert
- Guard rails: claim before resolution, double resolve, unauthorized access
- Fuzz: `testFuzz_WinnerTakeAll` (256 runs)