### PR TITLE
feat(backend): create market resolution API (#119)

### DIFF
--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
 import { WebhooksModule } from './webhooks/webhook.module';
 import { ReceiptsModule } from './receipts/receipt.module';
 import { NetworkModule } from './network/network.module';
+import { ResolutionModule } from './resolution/resolution.module';
 import { createKeyv } from '@keyv/redis';
 
 @Module({
@@ -60,6 +61,7 @@ import { createKeyv } from '@keyv/redis';
     WebhooksModule,
     ReceiptsModule,
     NetworkModule,
+    ResolutionModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/Backend/src/resolution/dto/resolution.dto.ts
+++ b/Backend/src/resolution/dto/resolution.dto.ts
@@ -1,0 +1,51 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsIn,
+  IsOptional,
+  IsNumber,
+  IsPositive,
+  MaxLength,
+} from 'class-validator';
+
+export class RequestResolutionDto {
+  @IsString()
+  @IsNotEmpty()
+  marketId: string;
+
+  @IsIn(['YES', 'NO', 'INVALID'])
+  outcome: 'YES' | 'NO' | 'INVALID';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  evidence?: string;
+}
+
+export class ConfirmResolutionDto {
+  @IsOptional()
+  @IsString()
+  txHash?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @IsPositive()
+  blockNumber?: number;
+}
+
+export class DisputeResolutionDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  reason: string;
+}
+
+export class ReviewDisputeDto {
+  @IsIn(['upheld', 'rejected'])
+  decision: 'upheld' | 'rejected';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  reviewNotes?: string;
+}

--- a/Backend/src/resolution/resolution.controller.ts
+++ b/Backend/src/resolution/resolution.controller.ts
@@ -1,0 +1,134 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  Request,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ResolutionService } from './resolution.service';
+import {
+  RequestResolutionDto,
+  ConfirmResolutionDto,
+  DisputeResolutionDto,
+  ReviewDisputeDto,
+} from './dto/resolution.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('resolution')
+@UseGuards(JwtAuthGuard)
+export class ResolutionController {
+  constructor(private readonly resolutionService: ResolutionService) {}
+
+  // ── Status endpoints ─────────────────────────────────────────────────────────
+
+  /** GET /api/resolution — list all resolutions, optionally filtered by status */
+  @Get()
+  list(@Query('status') status?: string) {
+    return this.resolutionService.listResolutions(status);
+  }
+
+  /** GET /api/resolution/market/:marketId — resolution status for a market */
+  @Get('market/:marketId')
+  getMarketStatus(@Param('marketId') marketId: string) {
+    return this.resolutionService.getStatus(marketId);
+  }
+
+  /** GET /api/resolution/:id — single resolution by id */
+  @Get(':id')
+  getOne(@Param('id') id: string) {
+    return this.resolutionService.getResolutionById(id);
+  }
+
+  // ── Manual resolution request ────────────────────────────────────────────────
+
+  /** POST /api/resolution — submit a manual resolution request */
+  @Post()
+  request(
+    @Request() req: { user: { id: string } },
+    @Body() dto: RequestResolutionDto,
+  ) {
+    return this.resolutionService.requestResolution(req.user.id, dto);
+  }
+
+  /** DELETE /api/resolution/:id — cancel a pending resolution request */
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  cancel(
+    @Request() req: { user: { id: string } },
+    @Param('id') id: string,
+  ) {
+    return this.resolutionService.cancelResolution(req.user.id, id);
+  }
+
+  // ── Confirmation ─────────────────────────────────────────────────────────────
+
+  /** POST /api/resolution/:id/confirm — confirm a resolution */
+  @Post(':id/confirm')
+  confirm(
+    @Request() req: { user: { id: string } },
+    @Param('id') id: string,
+    @Body() dto: ConfirmResolutionDto,
+  ) {
+    return this.resolutionService.confirmResolution(req.user.id, id, dto);
+  }
+
+  /** GET /api/resolution/:id/confirmations — list confirmations for a resolution */
+  @Get(':id/confirmations')
+  getConfirmations(@Param('id') id: string) {
+    return this.resolutionService.getConfirmations(id);
+  }
+
+  /** PATCH /api/resolution/:id/finalise — finalise a confirmed resolution */
+  @Patch(':id/finalise')
+  finalise(@Param('id') id: string) {
+    return this.resolutionService.finaliseResolution(id);
+  }
+
+  // ── Reports ──────────────────────────────────────────────────────────────────
+
+  /** GET /api/resolution/market/:marketId/report — generate resolution report */
+  @Get('market/:marketId/report')
+  report(@Param('marketId') marketId: string) {
+    return this.resolutionService.generateReport(marketId);
+  }
+
+  // ── Dispute workflow ─────────────────────────────────────────────────────────
+
+  /** POST /api/resolution/:id/dispute — raise a dispute on a resolution */
+  @Post(':id/dispute')
+  dispute(
+    @Request() req: { user: { id: string } },
+    @Param('id') id: string,
+    @Body() dto: DisputeResolutionDto,
+  ) {
+    return this.resolutionService.raiseDispute(req.user.id, id, dto);
+  }
+
+  /** GET /api/resolution/:id/disputes — list disputes for a resolution */
+  @Get(':id/disputes')
+  getDisputes(@Param('id') id: string) {
+    return this.resolutionService.getDisputes(id);
+  }
+
+  /** GET /api/resolution/disputes/:disputeId — get a single dispute */
+  @Get('disputes/:disputeId')
+  getDispute(@Param('disputeId') disputeId: string) {
+    return this.resolutionService.getDisputeById(disputeId);
+  }
+
+  /** PATCH /api/resolution/disputes/:disputeId/review — review (uphold/reject) a dispute */
+  @Patch('disputes/:disputeId/review')
+  reviewDispute(
+    @Param('disputeId') disputeId: string,
+    @Body() dto: ReviewDisputeDto,
+  ) {
+    return this.resolutionService.reviewDispute(disputeId, dto);
+  }
+}

--- a/Backend/src/resolution/resolution.entity.ts
+++ b/Backend/src/resolution/resolution.entity.ts
@@ -1,0 +1,63 @@
+export type ResolutionStatus =
+  | 'pending'
+  | 'requested'
+  | 'confirmed'
+  | 'disputed'
+  | 'resolved'
+  | 'cancelled';
+
+export type ResolutionOutcome = 'YES' | 'NO' | 'INVALID';
+
+export type DisputeStatus = 'open' | 'under_review' | 'upheld' | 'rejected';
+
+export interface MarketResolution {
+  id: string;
+  marketId: string;
+  /** User who submitted the manual resolution request */
+  requestedBy: string;
+  outcome: ResolutionOutcome;
+  status: ResolutionStatus;
+  /** Optional on-chain tx hash confirming the resolution */
+  txHash?: string;
+  /** Evidence or notes provided with the request */
+  evidence?: string;
+  requestedAt: Date;
+  confirmedAt?: Date;
+  resolvedAt?: Date;
+  cancelledAt?: Date;
+}
+
+export interface ResolutionDispute {
+  id: string;
+  resolutionId: string;
+  marketId: string;
+  /** User raising the dispute */
+  disputedBy: string;
+  reason: string;
+  status: DisputeStatus;
+  /** Admin/reviewer notes */
+  reviewNotes?: string;
+  raisedAt: Date;
+  reviewedAt?: Date;
+  resolvedAt?: Date;
+}
+
+export interface ResolutionConfirmation {
+  id: string;
+  resolutionId: string;
+  marketId: string;
+  confirmedBy: string;
+  txHash?: string;
+  blockNumber?: number;
+  confirmedAt: Date;
+}
+
+export interface ResolutionReport {
+  marketId: string;
+  resolution: MarketResolution | null;
+  confirmations: ResolutionConfirmation[];
+  disputes: ResolutionDispute[];
+  totalDisputes: number;
+  openDisputes: number;
+  generatedAt: Date;
+}

--- a/Backend/src/resolution/resolution.module.ts
+++ b/Backend/src/resolution/resolution.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ResolutionService } from './resolution.service';
+import { ResolutionController } from './resolution.controller';
+
+@Module({
+  controllers: [ResolutionController],
+  providers: [ResolutionService],
+  exports: [ResolutionService],
+})
+export class ResolutionModule {}

--- a/Backend/src/resolution/resolution.service.ts
+++ b/Backend/src/resolution/resolution.service.ts
@@ -1,0 +1,294 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  MarketResolution,
+  ResolutionDispute,
+  ResolutionConfirmation,
+  ResolutionReport,
+} from './resolution.entity';
+import {
+  RequestResolutionDto,
+  ConfirmResolutionDto,
+  DisputeResolutionDto,
+  ReviewDisputeDto,
+} from './dto/resolution.dto';
+
+@Injectable()
+export class ResolutionService {
+  private readonly logger = new Logger(ResolutionService.name);
+
+  private readonly resolutions = new Map<string, MarketResolution>();
+  /** marketId → resolutionId (one active resolution per market) */
+  private readonly resolutionByMarket = new Map<string, string>();
+  private readonly confirmations = new Map<string, ResolutionConfirmation>();
+  /** resolutionId → confirmation ids */
+  private readonly confirmationsByResolution = new Map<string, string[]>();
+  private readonly disputes = new Map<string, ResolutionDispute>();
+  /** resolutionId → dispute ids */
+  private readonly disputesByResolution = new Map<string, string[]>();
+
+  // ── Status ──────────────────────────────────────────────────────────────────
+
+  getStatus(marketId: string): MarketResolution | null {
+    const resolutionId = this.resolutionByMarket.get(marketId);
+    if (!resolutionId) return null;
+    return this.resolutions.get(resolutionId) ?? null;
+  }
+
+  getResolutionById(resolutionId: string): MarketResolution {
+    const resolution = this.resolutions.get(resolutionId);
+    if (!resolution) throw new NotFoundException('Resolution not found');
+    return resolution;
+  }
+
+  listResolutions(status?: string): MarketResolution[] {
+    const all = [...this.resolutions.values()];
+    if (!status) return all;
+    return all.filter((r) => r.status === status);
+  }
+
+  // ── Manual resolution request ────────────────────────────────────────────────
+
+  requestResolution(userId: string, dto: RequestResolutionDto): MarketResolution {
+    const existing = this.resolutionByMarket.get(dto.marketId);
+    if (existing) {
+      const res = this.resolutions.get(existing)!;
+      if (res.status !== 'cancelled') {
+        throw new ConflictException(
+          `Market ${dto.marketId} already has an active resolution (status: ${res.status})`,
+        );
+      }
+    }
+
+    const resolution: MarketResolution = {
+      id: uuidv4(),
+      marketId: dto.marketId,
+      requestedBy: userId,
+      outcome: dto.outcome,
+      status: 'requested',
+      evidence: dto.evidence,
+      requestedAt: new Date(),
+    };
+
+    this.resolutions.set(resolution.id, resolution);
+    this.resolutionByMarket.set(dto.marketId, resolution.id);
+    this.logger.log(
+      `Resolution requested for market ${dto.marketId} by user ${userId} — outcome: ${dto.outcome}`,
+    );
+    return resolution;
+  }
+
+  cancelResolution(userId: string, resolutionId: string): MarketResolution {
+    const resolution = this.getResolutionById(resolutionId);
+    if (resolution.requestedBy !== userId) {
+      throw new BadRequestException('Only the requester can cancel this resolution');
+    }
+    if (!['requested', 'pending'].includes(resolution.status)) {
+      throw new BadRequestException(`Cannot cancel a resolution with status: ${resolution.status}`);
+    }
+    resolution.status = 'cancelled';
+    resolution.cancelledAt = new Date();
+    this.logger.log(`Resolution ${resolutionId} cancelled by user ${userId}`);
+    return resolution;
+  }
+
+  // ── Confirmation ─────────────────────────────────────────────────────────────
+
+  confirmResolution(
+    userId: string,
+    resolutionId: string,
+    dto: ConfirmResolutionDto,
+  ): ResolutionConfirmation {
+    const resolution = this.getResolutionById(resolutionId);
+
+    if (!['requested', 'pending'].includes(resolution.status)) {
+      throw new BadRequestException(
+        `Cannot confirm a resolution with status: ${resolution.status}`,
+      );
+    }
+
+    const confirmation: ResolutionConfirmation = {
+      id: uuidv4(),
+      resolutionId,
+      marketId: resolution.marketId,
+      confirmedBy: userId,
+      txHash: dto.txHash,
+      blockNumber: dto.blockNumber,
+      confirmedAt: new Date(),
+    };
+
+    this.confirmations.set(confirmation.id, confirmation);
+
+    const existing = this.confirmationsByResolution.get(resolutionId) ?? [];
+    existing.push(confirmation.id);
+    this.confirmationsByResolution.set(resolutionId, existing);
+
+    // Mark resolution as confirmed once at least one confirmation is recorded
+    resolution.status = 'confirmed';
+    resolution.confirmedAt = new Date();
+    if (dto.txHash) resolution.txHash = dto.txHash;
+
+    this.logger.log(
+      `Resolution ${resolutionId} confirmed by user ${userId}${dto.txHash ? ` (tx: ${dto.txHash})` : ''}`,
+    );
+    return confirmation;
+  }
+
+  getConfirmations(resolutionId: string): ResolutionConfirmation[] {
+    this.getResolutionById(resolutionId); // ensure it exists
+    const ids = this.confirmationsByResolution.get(resolutionId) ?? [];
+    return ids.map((id) => this.confirmations.get(id)!).filter(Boolean);
+  }
+
+  // ── Finalise resolution ───────────────────────────────────────────────────────
+
+  finaliseResolution(resolutionId: string): MarketResolution {
+    const resolution = this.getResolutionById(resolutionId);
+
+    if (resolution.status !== 'confirmed') {
+      throw new BadRequestException(
+        `Resolution must be confirmed before finalising (current status: ${resolution.status})`,
+      );
+    }
+
+    const openDisputes = this.getDisputes(resolutionId).filter(
+      (d) => d.status === 'open' || d.status === 'under_review',
+    );
+    if (openDisputes.length > 0) {
+      throw new BadRequestException(
+        `Cannot finalise: ${openDisputes.length} open dispute(s) must be resolved first`,
+      );
+    }
+
+    resolution.status = 'resolved';
+    resolution.resolvedAt = new Date();
+    this.logger.log(`Resolution ${resolutionId} finalised — market ${resolution.marketId} resolved as ${resolution.outcome}`);
+    return resolution;
+  }
+
+  // ── Disputes ─────────────────────────────────────────────────────────────────
+
+  raiseDispute(
+    userId: string,
+    resolutionId: string,
+    dto: DisputeResolutionDto,
+  ): ResolutionDispute {
+    const resolution = this.getResolutionById(resolutionId);
+
+    if (!['requested', 'confirmed'].includes(resolution.status)) {
+      throw new BadRequestException(
+        `Cannot dispute a resolution with status: ${resolution.status}`,
+      );
+    }
+
+    const dispute: ResolutionDispute = {
+      id: uuidv4(),
+      resolutionId,
+      marketId: resolution.marketId,
+      disputedBy: userId,
+      reason: dto.reason,
+      status: 'open',
+      raisedAt: new Date(),
+    };
+
+    this.disputes.set(dispute.id, dispute);
+
+    const existing = this.disputesByResolution.get(resolutionId) ?? [];
+    existing.push(dispute.id);
+    this.disputesByResolution.set(resolutionId, existing);
+
+    // Flag the resolution as disputed
+    resolution.status = 'disputed';
+
+    this.logger.log(
+      `Dispute raised on resolution ${resolutionId} by user ${userId}`,
+    );
+    return dispute;
+  }
+
+  getDisputes(resolutionId: string): ResolutionDispute[] {
+    this.getResolutionById(resolutionId); // ensure it exists
+    const ids = this.disputesByResolution.get(resolutionId) ?? [];
+    return ids.map((id) => this.disputes.get(id)!).filter(Boolean);
+  }
+
+  getDisputeById(disputeId: string): ResolutionDispute {
+    const dispute = this.disputes.get(disputeId);
+    if (!dispute) throw new NotFoundException('Dispute not found');
+    return dispute;
+  }
+
+  reviewDispute(disputeId: string, dto: ReviewDisputeDto): ResolutionDispute {
+    const dispute = this.getDisputeById(disputeId);
+
+    if (dispute.status !== 'open' && dispute.status !== 'under_review') {
+      throw new BadRequestException(`Dispute is already ${dispute.status}`);
+    }
+
+    dispute.status = dto.decision === 'upheld' ? 'upheld' : 'rejected';
+    dispute.reviewNotes = dto.reviewNotes;
+    dispute.reviewedAt = new Date();
+    dispute.resolvedAt = new Date();
+
+    // If upheld, revert resolution to requested so it can be re-evaluated
+    if (dto.decision === 'upheld') {
+      const resolution = this.resolutions.get(dispute.resolutionId);
+      if (resolution) {
+        resolution.status = 'requested';
+        resolution.confirmedAt = undefined;
+        this.logger.log(
+          `Dispute ${disputeId} upheld — resolution ${dispute.resolutionId} reverted to requested`,
+        );
+      }
+    } else {
+      // If all disputes on this resolution are now rejected, restore confirmed status
+      const allDisputes = this.getDisputes(dispute.resolutionId);
+      const anyOpen = allDisputes.some(
+        (d) => d.status === 'open' || d.status === 'under_review',
+      );
+      if (!anyOpen) {
+        const resolution = this.resolutions.get(dispute.resolutionId);
+        if (resolution && resolution.status === 'disputed') {
+          resolution.status = 'confirmed';
+          this.logger.log(
+            `All disputes on resolution ${dispute.resolutionId} rejected — status restored to confirmed`,
+          );
+        }
+      }
+    }
+
+    return dispute;
+  }
+
+  // ── Reports ──────────────────────────────────────────────────────────────────
+
+  generateReport(marketId: string): ResolutionReport {
+    const resolution = this.getStatus(marketId);
+    const resolutionId = resolution?.id;
+
+    const confirmations = resolutionId ? this.getConfirmations(resolutionId) : [];
+    const disputes = resolutionId ? this.getDisputes(resolutionId) : [];
+    const openDisputes = disputes.filter(
+      (d) => d.status === 'open' || d.status === 'under_review',
+    ).length;
+
+    const report: ResolutionReport = {
+      marketId,
+      resolution,
+      confirmations,
+      disputes,
+      totalDisputes: disputes.length,
+      openDisputes,
+      generatedAt: new Date(),
+    };
+
+    this.logger.log(`Resolution report generated for market ${marketId}`);
+    return report;
+  }
+}


### PR DESCRIPTION
- Add ResolutionModule at Backend/src/resolution/
- resolution.entity.ts — MarketResolution, ResolutionDispute, ResolutionConfirmation, ResolutionReport types
- dto/resolution.dto.ts — RequestResolutionDto, ConfirmResolutionDto, DisputeResolutionDto, ReviewDisputeDto with class-validator
- resolution.service.ts — full in-memory service covering:
    - Status: getStatus(marketId), getResolutionById, listResolutions(status?)
    - Manual requests: requestResolution, cancelResolution (one active resolution per market enforced)
    - Confirmations: confirmResolution (records tx hash / block), getConfirmations
    - Finalisation: finaliseResolution (blocks if open disputes remain)
    - Disputes: raiseDispute, getDisputes, getDisputeById, reviewDispute (upheld reverts to requested; all rejected restores confirmed)
    - Reports: generateReport (resolution + confirmations + disputes + counts)
- resolution.controller.ts — REST endpoints under /api/resolution, all JWT-guarded:
    GET  /resolution                          list all (filter by ?status)
    GET  /resolution/market/:marketId         resolution status for a market
    GET  /resolution/:id                      single resolution
    POST /resolution                          submit manual resolution request
    DELETE /resolution/:id                    cancel pending request
    POST /resolution/:id/confirm              confirm resolution
    GET  /resolution/:id/confirmations        list confirmations
    PATCH /resolution/:id/finalise            finalise confirmed resolution
    GET  /resolution/market/:marketId/report  generate resolution report
    POST /resolution/:id/dispute              raise dispute
    GET  /resolution/:id/disputes             list disputes
    GET  /resolution/disputes/:disputeId      single dispute
    PATCH /resolution/disputes/:disputeId/review  review dispute (uphold/reject)
- Register ResolutionModule in AppModule
closes #119