### PR TITLE
[166] [Backend] Add liquidity provision service

### DIFF
--- a/Backend/src/ai/ai.service.ts
+++ b/Backend/src/ai/ai.service.ts
@@ -65,7 +65,7 @@ export class AiService {
   }
 
   async getCachedAnalysis(marketId: string): Promise<MarketAnalysis | null> {
-    return this.cache.get<MarketAnalysis>(`ai:analysis:${marketId}`) ?? null;
+    return (await this.cache.get<MarketAnalysis>(`ai:analysis:${marketId}`)) ?? null;
   }
 
   private async fetchFromGroq(

--- a/Backend/src/categories/categories.service.ts
+++ b/Backend/src/categories/categories.service.ts
@@ -57,7 +57,7 @@ export class CategoriesService {
       }
 
       // Check for deeper circularity
-      let currentParentId = parentId;
+      let currentParentId: string | null = parentId;
       while (currentParentId) {
         const currentParent = await this.categoryModel
           .findById(currentParentId)
@@ -67,7 +67,7 @@ export class CategoriesService {
             'Circular reference detected in category hierarchy',
           );
         }
-        currentParentId = currentParent?.parentId?.toString() || null;
+        currentParentId = currentParent?.parentId?.toString() ?? null;
       }
     }
 

--- a/Backend/src/liquidity/dto/liquidity.dto.ts
+++ b/Backend/src/liquidity/dto/liquidity.dto.ts
@@ -1,0 +1,66 @@
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class AddLiquidityDto {
+  @IsString()
+  @IsNotEmpty()
+  marketId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  walletAddress: string;
+
+  @IsNumber()
+  @Min(0.000001)
+  @Type(() => Number)
+  amountEth: number;
+
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  autoManage?: boolean;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  @Type(() => Number)
+  targetYesRatio?: number;
+}
+
+export class RemoveLiquidityDto {
+  @IsString()
+  @IsNotEmpty()
+  marketId: string;
+
+  @IsNumber()
+  @Min(0.000001)
+  @Type(() => Number)
+  shareAmount: number;
+}
+
+export class AutoManagePositionDto {
+  @IsString()
+  @IsNotEmpty()
+  marketId: string;
+
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  autoManage?: boolean;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  @Type(() => Number)
+  targetYesRatio?: number;
+}

--- a/Backend/src/liquidity/liquidity.controller.ts
+++ b/Backend/src/liquidity/liquidity.controller.ts
@@ -1,11 +1,80 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { LiquidityService } from './liquidity.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import {
+  AddLiquidityDto,
+  AutoManagePositionDto,
+  RemoveLiquidityDto,
+} from './dto/liquidity.dto';
 
 @Controller('liquidity')
 @UseGuards(JwtAuthGuard)
 export class LiquidityController {
   constructor(private readonly liquidityService: LiquidityService) {}
+
+  @Post('add')
+  addLiquidity(
+    @Request() req: { user: { id: string } },
+    @Body() dto: AddLiquidityDto,
+  ) {
+    return this.liquidityService.addLiquidity(
+      req.user.id,
+      dto.marketId,
+      dto.walletAddress,
+      dto.amountEth,
+      dto.autoManage,
+      dto.targetYesRatio,
+    );
+  }
+
+  @Post('remove')
+  removeLiquidity(
+    @Request() req: { user: { id: string } },
+    @Body() dto: RemoveLiquidityDto,
+  ) {
+    return this.liquidityService.removeLiquidity(
+      req.user.id,
+      dto.marketId,
+      dto.shareAmount,
+    );
+  }
+
+  @Get('positions/mine')
+  getMyPositions(@Request() req: { user: { id: string } }) {
+    return this.liquidityService.getUserPositions(req.user.id);
+  }
+
+  @Get('analytics')
+  getLpAnalytics() {
+    return this.liquidityService.getLiquidityAnalytics();
+  }
+
+  @Post('automation/run')
+  runAutomation(@Request() req: { user: { id: string } }) {
+    return this.liquidityService.runAutomation(req.user.id);
+  }
+
+  @Patch('automation/config')
+  configureAutomation(
+    @Request() req: { user: { id: string } },
+    @Body() dto: AutoManagePositionDto,
+  ) {
+    return this.liquidityService.configureAutomation(
+      req.user.id,
+      dto.marketId,
+      dto.autoManage,
+      dto.targetYesRatio,
+    );
+  }
 
   @Get('report')
   getReport() {

--- a/Backend/src/liquidity/liquidity.service.spec.ts
+++ b/Backend/src/liquidity/liquidity.service.spec.ts
@@ -1,0 +1,119 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MarketResolverService } from '../markets/market-resolver.service';
+import { LiquidityService } from './liquidity.service';
+
+describe('LiquidityService', () => {
+  let service: LiquidityService;
+  let marketResolver: MarketResolverService;
+
+  const cacheMock = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+  };
+
+  const baseMarket = {
+    id: 'market-1',
+    title: 'Flight delay over 2 hours',
+    deadline: new Date('2030-01-01T00:00:00.000Z'),
+    totalYesStake: 4_000_000_000_000_000_000n,
+    totalNoStake: 2_000_000_000_000_000_000n,
+    status: 'active' as const,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    cacheMock.get.mockResolvedValue(undefined);
+    cacheMock.set.mockResolvedValue(undefined);
+    cacheMock.del.mockResolvedValue(undefined);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LiquidityService,
+        MarketResolverService,
+        {
+          provide: CACHE_MANAGER,
+          useValue: cacheMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<LiquidityService>(LiquidityService);
+    marketResolver = module.get<MarketResolverService>(MarketResolverService);
+    marketResolver.registerMarket(baseMarket);
+  });
+
+  it('tracks LP positions and supports add/remove lifecycle', async () => {
+    const position = await service.addLiquidity(
+      'user-1',
+      'market-1',
+      '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      10,
+      true,
+      0.58,
+    );
+
+    expect(position.marketId).toBe('market-1');
+    expect(position.autoManage).toBe(true);
+    expect(position.targetYesRatio).toBe(0.58);
+    expect(position.shares).toBeGreaterThan(0);
+
+    const removal = await service.removeLiquidity('user-1', 'market-1', 3);
+    expect(Number.parseFloat(removal.withdrawnEth)).toBeGreaterThan(0);
+    expect(Number.parseFloat(removal.claimedFeesEth)).toBeGreaterThanOrEqual(0);
+    expect(Number.parseFloat(removal.claimedRewardsEth)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('accrues rewards and fees for open LP positions', async () => {
+    await service.addLiquidity(
+      'user-2',
+      'market-1',
+      '0x66f820a414680B5bcda5eECA5dea238543F42054',
+      5,
+    );
+
+    const internals = service as unknown as {
+      positions: Map<string, { lastAccrualAt: Date }>;
+    };
+    const key = 'user-2:market-1';
+    const position = internals.positions.get(key);
+    if (!position) {
+      throw new Error('Expected test position to exist');
+    }
+
+    position.lastAccrualAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const positions = await service.getUserPositions('user-2');
+    expect(positions).toHaveLength(1);
+    expect(Number.parseFloat(positions[0].rewardsAccruedEth)).toBeGreaterThan(0);
+    expect(Number.parseFloat(positions[0].feesAccruedEth)).toBeGreaterThan(0);
+  });
+
+  it('provides liquidity analytics and automation support', async () => {
+    await service.addLiquidity(
+      'user-3',
+      'market-1',
+      '0x66f820a414680B5bcda5eECA5dea238543F42054',
+      8,
+      true,
+      0.2,
+    );
+
+    const result = await service.runAutomation('user-3');
+    expect(result).toHaveLength(1);
+    expect(['REBALANCED', 'SKIPPED']).toContain(result[0].action);
+
+    const analytics = await service.getLiquidityAnalytics();
+    expect(analytics.totalProviders).toBe(1);
+    expect(analytics.totalTrackedMarkets).toBeGreaterThanOrEqual(1);
+    expect(Number.parseFloat(analytics.totalLiquidityEth)).toBeGreaterThan(0);
+    expect(analytics.marketBreakdown).toHaveLength(1);
+  });
+
+  it('rejects invalid wallet addresses', async () => {
+    await expect(
+      service.addLiquidity('user-4', 'market-1', 'not-an-address', 1),
+    ).rejects.toThrow('Invalid wallet address');
+  });
+});

--- a/Backend/src/liquidity/liquidity.service.ts
+++ b/Backend/src/liquidity/liquidity.service.ts
@@ -1,17 +1,29 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import type { Cache } from 'cache-manager';
 import { create, all } from 'mathjs';
+import Web3 from 'web3';
 import {
   MarketResolverService,
   Market,
 } from '../markets/market-resolver.service';
 
 const math = create(all);
+const web3 = new Web3();
 
 const CACHE_TTL = 60_000; // 1 minute
 const REPORT_KEY = 'liquidity:report';
+const LP_ANALYTICS_KEY = 'liquidity:lp-analytics';
+const BASE_REWARD_APY = 0.12;
+const BASE_FEE_APY = 0.06;
+const AUTOMATION_THRESHOLD = 0.08;
 
 export interface MarketLiquidity {
   marketId: string;
@@ -49,6 +61,87 @@ export interface LiquidityReport {
   health: LiquidityHealth;
 }
 
+export interface LiquidityPoolState {
+  marketId: string;
+  totalLiquidityEth: number;
+  totalShares: number;
+  totalFeesDistributedEth: number;
+  totalRewardsDistributedEth: number;
+  updatedAt: Date;
+}
+
+export interface LiquidityPosition {
+  userId: string;
+  marketId: string;
+  walletAddress: string;
+  shares: number;
+  principalEth: number;
+  removedPrincipalEth: number;
+  rewardsAccruedEth: number;
+  feesAccruedEth: number;
+  claimedRewardsEth: number;
+  claimedFeesEth: number;
+  autoManage: boolean;
+  targetYesRatio: number;
+  createdAt: Date;
+  updatedAt: Date;
+  lastAccrualAt: Date;
+  automationExecutions: number;
+}
+
+export interface LiquidityPositionView {
+  marketId: string;
+  walletAddress: string;
+  shares: number;
+  shareRatio: number;
+  principalEth: string;
+  removedPrincipalEth: string;
+  rewardsAccruedEth: string;
+  feesAccruedEth: string;
+  totalEarnedEth: string;
+  estimatedPositionValueEth: string;
+  autoManage: boolean;
+  targetYesRatio: number;
+  createdAt: string;
+  updatedAt: string;
+  lastAccrualAt: string;
+  automationExecutions: number;
+}
+
+export interface LiquidityAnalytics {
+  generatedAt: string;
+  totalProviders: number;
+  totalTrackedMarkets: number;
+  totalLiquidityEth: string;
+  totalPrincipalEth: string;
+  totalRewardsEth: string;
+  totalFeesEth: string;
+  averageEstimatedApy: number;
+  topProviders: Array<{
+    userId: string;
+    estimatedValueEth: string;
+    totalEarnedEth: string;
+    positions: number;
+  }>;
+  marketBreakdown: Array<{
+    marketId: string;
+    providers: number;
+    totalLiquidityEth: string;
+    totalRewardsEth: string;
+    totalFeesEth: string;
+    autoManagedProviders: number;
+  }>;
+}
+
+export interface AutomationExecution {
+  marketId: string;
+  userId: string;
+  action: 'REBALANCED' | 'SKIPPED';
+  bonusRewardEth: string;
+  deviation: number;
+  executedAt: string;
+}
+
 const WEI = 1e18;
 
 function weiToEth(wei: bigint): number {
@@ -58,6 +151,8 @@ function weiToEth(wei: bigint): number {
 @Injectable()
 export class LiquidityService {
   private readonly logger = new Logger(LiquidityService.name);
+  private readonly pools = new Map<string, LiquidityPoolState>();
+  private readonly positions = new Map<string, LiquidityPosition>();
 
   constructor(
     private readonly marketResolver: MarketResolverService,
@@ -70,6 +165,389 @@ export class LiquidityService {
     const cached = await this.cache.get<LiquidityReport>(REPORT_KEY);
     if (cached) return cached;
     return this.buildAndCacheReport();
+  }
+
+  async addLiquidity(
+    userId: string,
+    marketId: string,
+    walletAddress: string,
+    amountEth: number,
+    autoManage?: boolean,
+    targetYesRatio?: number,
+  ): Promise<LiquidityPositionView> {
+    this.assertPositive(amountEth, 'Liquidity amount must be positive');
+
+    const market = this.marketResolver.getMarket(marketId);
+    if (!market) throw new NotFoundException('Market not found');
+
+    const normalizedAddress = this.normalizeWallet(walletAddress);
+    const key = this.positionKey(userId, marketId);
+    const now = new Date();
+
+    const pool = this.ensurePool(market);
+    const existing = this.positions.get(key);
+    if (existing) this.accruePosition(existing, pool, now);
+
+    const mintedShares =
+      pool.totalShares <= 0 || pool.totalLiquidityEth <= 0
+        ? amountEth
+        : math.number(
+            math.round(
+              math.divide(
+                math.multiply(amountEth, pool.totalShares),
+                pool.totalLiquidityEth,
+              ),
+              12,
+            ),
+          );
+
+    const position: LiquidityPosition =
+      existing ??
+      ({
+        userId,
+        marketId,
+        walletAddress: normalizedAddress,
+        shares: 0,
+        principalEth: 0,
+        removedPrincipalEth: 0,
+        rewardsAccruedEth: 0,
+        feesAccruedEth: 0,
+        claimedRewardsEth: 0,
+        claimedFeesEth: 0,
+        autoManage: autoManage ?? false,
+        targetYesRatio: this.normalizeTargetRatio(targetYesRatio),
+        createdAt: now,
+        updatedAt: now,
+        lastAccrualAt: now,
+        automationExecutions: 0,
+      } as LiquidityPosition);
+
+    if (typeof autoManage === 'boolean') {
+      position.autoManage = autoManage;
+    }
+    if (typeof targetYesRatio === 'number') {
+      position.targetYesRatio = this.normalizeTargetRatio(targetYesRatio);
+    }
+
+    position.walletAddress = normalizedAddress;
+    position.shares = this.round12(position.shares + mintedShares);
+    position.principalEth = this.round12(position.principalEth + amountEth);
+    position.updatedAt = now;
+    position.lastAccrualAt = now;
+
+    pool.totalLiquidityEth = this.round12(pool.totalLiquidityEth + amountEth);
+    pool.totalShares = this.round12(pool.totalShares + mintedShares);
+    pool.updatedAt = now;
+
+    this.positions.set(key, position);
+    await this.invalidateCaches();
+    return this.toPositionView(position, pool);
+  }
+
+  async removeLiquidity(
+    userId: string,
+    marketId: string,
+    shareAmount: number,
+  ): Promise<
+    LiquidityPositionView & {
+      withdrawnEth: string;
+      claimedRewardsEth: string;
+      claimedFeesEth: string;
+    }
+  > {
+    this.assertPositive(shareAmount, 'Share amount must be positive');
+
+    const key = this.positionKey(userId, marketId);
+    const position = this.positions.get(key);
+    if (!position) throw new NotFoundException('Liquidity position not found');
+
+    const pool = this.pools.get(marketId);
+    if (!pool || pool.totalShares <= 0 || pool.totalLiquidityEth <= 0) {
+      throw new BadRequestException('Liquidity pool has no available liquidity');
+    }
+
+    const now = new Date();
+    this.accruePosition(position, pool, now);
+
+    if (shareAmount > position.shares) {
+      throw new BadRequestException('Insufficient LP shares');
+    }
+
+    const withdrawnEth = this.round12(
+      math.number(
+        math.round(
+          math.divide(math.multiply(shareAmount, pool.totalLiquidityEth), pool.totalShares),
+          12,
+        ),
+      ),
+    );
+
+    const claimedRewardsEth = this.round12(
+      math.number(
+        math.round(
+          math.divide(math.multiply(position.rewardsAccruedEth, shareAmount), position.shares),
+          12,
+        ),
+      ),
+    );
+    const claimedFeesEth = this.round12(
+      math.number(
+        math.round(
+          math.divide(math.multiply(position.feesAccruedEth, shareAmount), position.shares),
+          12,
+        ),
+      ),
+    );
+
+    position.rewardsAccruedEth = this.round12(
+      position.rewardsAccruedEth - claimedRewardsEth,
+    );
+    position.feesAccruedEth = this.round12(position.feesAccruedEth - claimedFeesEth);
+    position.claimedRewardsEth = this.round12(
+      position.claimedRewardsEth + claimedRewardsEth,
+    );
+    position.claimedFeesEth = this.round12(position.claimedFeesEth + claimedFeesEth);
+
+    const principalReduction = this.round12(
+      math.number(
+        math.round(
+          math.divide(math.multiply(position.principalEth, shareAmount), position.shares),
+          12,
+        ),
+      ),
+    );
+    position.principalEth = this.round12(position.principalEth - principalReduction);
+    position.removedPrincipalEth = this.round12(
+      position.removedPrincipalEth + principalReduction,
+    );
+    position.shares = this.round12(position.shares - shareAmount);
+    position.updatedAt = now;
+    position.lastAccrualAt = now;
+
+    pool.totalLiquidityEth = this.round12(pool.totalLiquidityEth - withdrawnEth);
+    pool.totalShares = this.round12(pool.totalShares - shareAmount);
+    pool.totalRewardsDistributedEth = this.round12(
+      pool.totalRewardsDistributedEth + claimedRewardsEth,
+    );
+    pool.totalFeesDistributedEth = this.round12(
+      pool.totalFeesDistributedEth + claimedFeesEth,
+    );
+    pool.updatedAt = now;
+
+    if (position.shares <= 0.000000000001) {
+      this.positions.delete(key);
+    } else {
+      this.positions.set(key, position);
+    }
+
+    await this.invalidateCaches();
+
+    const latestPosition = this.positions.get(key) ?? {
+      ...position,
+      shares: 0,
+      principalEth: 0,
+      rewardsAccruedEth: 0,
+      feesAccruedEth: 0,
+    };
+
+    return {
+      ...this.toPositionView(latestPosition, pool),
+      withdrawnEth: this.formatEth(withdrawnEth),
+      claimedRewardsEth: this.formatEth(claimedRewardsEth),
+      claimedFeesEth: this.formatEth(claimedFeesEth),
+    };
+  }
+
+  async getUserPositions(userId: string): Promise<LiquidityPositionView[]> {
+    const now = new Date();
+    const userPositions = [...this.positions.values()].filter(
+      (position) => position.userId === userId,
+    );
+
+    userPositions.forEach((position) => {
+      const pool = this.pools.get(position.marketId);
+      if (pool) this.accruePosition(position, pool, now);
+    });
+
+    return userPositions.map((position) => {
+      const pool = this.pools.get(position.marketId) ?? this.createEmptyPool(position.marketId);
+      return this.toPositionView(position, pool);
+    });
+  }
+
+  async getLiquidityAnalytics(): Promise<LiquidityAnalytics> {
+    const cached = await this.cache.get<LiquidityAnalytics>(LP_ANALYTICS_KEY);
+    if (cached) return cached;
+
+    const now = new Date();
+    this.positions.forEach((position) => {
+      const pool = this.pools.get(position.marketId);
+      if (pool) this.accruePosition(position, pool, now);
+    });
+
+    const positions = [...this.positions.values()];
+    const providers = new Set(positions.map((p) => p.userId));
+    const pools = [...this.pools.values()];
+    const totals = positions.reduce(
+      (acc, position) => {
+        const pool = this.pools.get(position.marketId);
+        const positionValue = this.estimatePositionValue(position, pool);
+        acc.principal += position.principalEth;
+        acc.rewards += position.rewardsAccruedEth + position.claimedRewardsEth;
+        acc.fees += position.feesAccruedEth + position.claimedFeesEth;
+        acc.positionValue += positionValue;
+        return acc;
+      },
+      { principal: 0, rewards: 0, fees: 0, positionValue: 0 },
+    );
+
+    const topProviders = [...providers]
+      .map((userId) => {
+        const providerPositions = positions.filter((p) => p.userId === userId);
+        const value = providerPositions.reduce(
+          (sum, position) =>
+            sum +
+            this.estimatePositionValue(position, this.pools.get(position.marketId)),
+          0,
+        );
+        const earnings = providerPositions.reduce(
+          (sum, position) =>
+            sum +
+            position.rewardsAccruedEth +
+            position.feesAccruedEth +
+            position.claimedRewardsEth +
+            position.claimedFeesEth,
+          0,
+        );
+        return {
+          userId,
+          estimatedValueEth: this.formatEth(value),
+          totalEarnedEth: this.formatEth(earnings),
+          positions: providerPositions.length,
+        };
+      })
+      .sort((a, b) => Number.parseFloat(b.estimatedValueEth) - Number.parseFloat(a.estimatedValueEth))
+      .slice(0, 10);
+
+    const marketBreakdown = pools.map((pool) => {
+      const marketPositions = positions.filter((p) => p.marketId === pool.marketId);
+      const rewards = marketPositions.reduce(
+        (sum, p) => sum + p.rewardsAccruedEth + p.claimedRewardsEth,
+        0,
+      );
+      const fees = marketPositions.reduce(
+        (sum, p) => sum + p.feesAccruedEth + p.claimedFeesEth,
+        0,
+      );
+      return {
+        marketId: pool.marketId,
+        providers: marketPositions.length,
+        totalLiquidityEth: this.formatEth(pool.totalLiquidityEth),
+        totalRewardsEth: this.formatEth(rewards),
+        totalFeesEth: this.formatEth(fees),
+        autoManagedProviders: marketPositions.filter((p) => p.autoManage).length,
+      };
+    });
+
+    const estimatedApy = totals.principal > 0 ? ((totals.rewards + totals.fees) / totals.principal) * 100 : 0;
+
+    const analytics: LiquidityAnalytics = {
+      generatedAt: now.toISOString(),
+      totalProviders: providers.size,
+      totalTrackedMarkets: pools.length,
+      totalLiquidityEth: this.formatEth(
+        pools.reduce((sum, pool) => sum + pool.totalLiquidityEth, 0),
+      ),
+      totalPrincipalEth: this.formatEth(totals.principal),
+      totalRewardsEth: this.formatEth(totals.rewards),
+      totalFeesEth: this.formatEth(totals.fees),
+      averageEstimatedApy: this.round6(estimatedApy),
+      topProviders,
+      marketBreakdown,
+    };
+
+    await this.cache.set(LP_ANALYTICS_KEY, analytics, CACHE_TTL);
+    return analytics;
+  }
+
+  async runAutomation(userId: string): Promise<AutomationExecution[]> {
+    const now = new Date();
+    const executions: AutomationExecution[] = [];
+
+    const userPositions = [...this.positions.values()].filter(
+      (position) => position.userId === userId && position.autoManage,
+    );
+
+    for (const position of userPositions) {
+      const market = this.marketResolver.getMarket(position.marketId);
+      const pool = this.pools.get(position.marketId);
+      if (!market || !pool) continue;
+
+      this.accruePosition(position, pool, now);
+      const currentYesRatio = this.marketYesRatio(market);
+      const deviation = math.abs(currentYesRatio - position.targetYesRatio);
+
+      if (deviation >= AUTOMATION_THRESHOLD) {
+        const bonusReward = this.round12(position.principalEth * 0.0015 * deviation);
+        position.rewardsAccruedEth = this.round12(position.rewardsAccruedEth + bonusReward);
+        position.automationExecutions += 1;
+        position.updatedAt = now;
+        position.lastAccrualAt = now;
+        this.positions.set(this.positionKey(position.userId, position.marketId), position);
+
+        executions.push({
+          marketId: position.marketId,
+          userId,
+          action: 'REBALANCED',
+          bonusRewardEth: this.formatEth(bonusReward),
+          deviation: this.round6(deviation),
+          executedAt: now.toISOString(),
+        });
+      } else {
+        executions.push({
+          marketId: position.marketId,
+          userId,
+          action: 'SKIPPED',
+          bonusRewardEth: this.formatEth(0),
+          deviation: this.round6(deviation),
+          executedAt: now.toISOString(),
+        });
+      }
+    }
+
+    if (executions.some((item) => item.action === 'REBALANCED')) {
+      await this.invalidateCaches();
+    }
+
+    return executions;
+  }
+
+  async configureAutomation(
+    userId: string,
+    marketId: string,
+    autoManage?: boolean,
+    targetYesRatio?: number,
+  ): Promise<LiquidityPositionView> {
+    const key = this.positionKey(userId, marketId);
+    const position = this.positions.get(key);
+    if (!position) throw new NotFoundException('Liquidity position not found');
+    const pool = this.pools.get(marketId) ?? this.createEmptyPool(marketId);
+
+    const now = new Date();
+    this.accruePosition(position, pool, now);
+
+    if (typeof autoManage === 'boolean') {
+      position.autoManage = autoManage;
+    }
+    if (typeof targetYesRatio === 'number') {
+      position.targetYesRatio = this.normalizeTargetRatio(targetYesRatio);
+    }
+    position.updatedAt = now;
+    position.lastAccrualAt = now;
+
+    this.positions.set(key, position);
+    await this.invalidateCaches();
+    return this.toPositionView(position, pool);
   }
 
   async getMarketLiquidity(marketId: string): Promise<MarketLiquidity | null> {
@@ -94,6 +572,21 @@ export class LiquidityService {
   async refreshReport(): Promise<void> {
     this.logger.log('Refreshing liquidity report...');
     await this.buildAndCacheReport();
+  }
+
+  @Cron(CronExpression.EVERY_30_MINUTES)
+  async accrueAllPositions(): Promise<void> {
+    if (!this.positions.size) return;
+
+    const now = new Date();
+    this.positions.forEach((position) => {
+      const pool = this.pools.get(position.marketId);
+      if (pool) {
+        this.accruePosition(position, pool, now);
+      }
+    });
+
+    await this.invalidateCaches();
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────
@@ -128,6 +621,169 @@ export class LiquidityService {
 
     await this.cache.set(REPORT_KEY, report, CACHE_TTL);
     return report;
+  }
+
+  private ensurePool(market: Market): LiquidityPoolState {
+    const existing = this.pools.get(market.id);
+    if (existing) return existing;
+
+    const seededLiquidity = this.round12(weiToEth(market.totalYesStake + market.totalNoStake));
+    const now = new Date();
+    const pool: LiquidityPoolState = {
+      marketId: market.id,
+      totalLiquidityEth: seededLiquidity,
+      totalShares: seededLiquidity,
+      totalFeesDistributedEth: 0,
+      totalRewardsDistributedEth: 0,
+      updatedAt: now,
+    };
+
+    this.pools.set(market.id, pool);
+    return pool;
+  }
+
+  private createEmptyPool(marketId: string): LiquidityPoolState {
+    return {
+      marketId,
+      totalLiquidityEth: 0,
+      totalShares: 0,
+      totalFeesDistributedEth: 0,
+      totalRewardsDistributedEth: 0,
+      updatedAt: new Date(),
+    };
+  }
+
+  private accruePosition(
+    position: LiquidityPosition,
+    pool: LiquidityPoolState,
+    now: Date,
+  ): void {
+    const elapsedMs = now.getTime() - position.lastAccrualAt.getTime();
+    if (elapsedMs <= 0) return;
+
+    if (position.shares <= 0 || pool.totalShares <= 0 || pool.totalLiquidityEth <= 0) {
+      position.lastAccrualAt = now;
+      return;
+    }
+
+    const hours = elapsedMs / (1000 * 60 * 60);
+    const shareRatio = position.shares / pool.totalShares;
+    const exposure = pool.totalLiquidityEth * shareRatio;
+    const utilizationBoost = 1 + Math.min(0.75, shareRatio * 2.5);
+
+    const rewardRatePerHour = BASE_REWARD_APY / (365 * 24);
+    const feeRatePerHour = BASE_FEE_APY / (365 * 24);
+
+    const reward = this.round12(exposure * rewardRatePerHour * hours * utilizationBoost);
+    const fee = this.round12(exposure * feeRatePerHour * hours * (1 + shareRatio));
+
+    position.rewardsAccruedEth = this.round12(position.rewardsAccruedEth + reward);
+    position.feesAccruedEth = this.round12(position.feesAccruedEth + fee);
+    position.updatedAt = now;
+    position.lastAccrualAt = now;
+  }
+
+  private toPositionView(
+    position: LiquidityPosition,
+    pool: LiquidityPoolState,
+  ): LiquidityPositionView {
+    const shareRatio =
+      pool.totalShares > 0 ? this.round6(position.shares / pool.totalShares) : 0;
+
+    const positionValue = this.estimatePositionValue(position, pool);
+    const totalEarned =
+      position.rewardsAccruedEth +
+      position.feesAccruedEth +
+      position.claimedRewardsEth +
+      position.claimedFeesEth;
+
+    return {
+      marketId: position.marketId,
+      walletAddress: position.walletAddress,
+      shares: this.round6(position.shares),
+      shareRatio,
+      principalEth: this.formatEth(position.principalEth),
+      removedPrincipalEth: this.formatEth(position.removedPrincipalEth),
+      rewardsAccruedEth: this.formatEth(position.rewardsAccruedEth),
+      feesAccruedEth: this.formatEth(position.feesAccruedEth),
+      totalEarnedEth: this.formatEth(totalEarned),
+      estimatedPositionValueEth: this.formatEth(positionValue),
+      autoManage: position.autoManage,
+      targetYesRatio: this.round6(position.targetYesRatio),
+      createdAt: position.createdAt.toISOString(),
+      updatedAt: position.updatedAt.toISOString(),
+      lastAccrualAt: position.lastAccrualAt.toISOString(),
+      automationExecutions: position.automationExecutions,
+    };
+  }
+
+  private estimatePositionValue(
+    position: LiquidityPosition,
+    pool?: LiquidityPoolState,
+  ): number {
+    if (!pool || pool.totalShares <= 0 || pool.totalLiquidityEth <= 0) {
+      return this.round12(position.principalEth + position.rewardsAccruedEth + position.feesAccruedEth);
+    }
+
+    const underlying = math.number(
+      math.round(
+        math.divide(math.multiply(position.shares, pool.totalLiquidityEth), pool.totalShares),
+        12,
+      ),
+    );
+    return this.round12(underlying + position.rewardsAccruedEth + position.feesAccruedEth);
+  }
+
+  private positionKey(userId: string, marketId: string): string {
+    return `${userId}:${marketId}`;
+  }
+
+  private assertPositive(value: number, message: string): void {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new BadRequestException(message);
+    }
+  }
+
+  private normalizeTargetRatio(value?: number): number {
+    if (value === undefined || value === null) return 0.5;
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new BadRequestException('targetYesRatio must be between 0 and 1');
+    }
+    return this.round6(value);
+  }
+
+  private normalizeWallet(address: string): string {
+    if (!web3.utils.isAddress(address)) {
+      throw new BadRequestException('Invalid wallet address');
+    }
+    return web3.utils.toChecksumAddress(address);
+  }
+
+  private marketYesRatio(market: Market): number {
+    const yes = weiToEth(market.totalYesStake);
+    const no = weiToEth(market.totalNoStake);
+    const total = yes + no;
+    if (total <= 0) return 0.5;
+    return this.round6(yes / total);
+  }
+
+  private round6(value: number): number {
+    return math.number(math.round(value, 6));
+  }
+
+  private round12(value: number): number {
+    return math.number(math.round(value, 12));
+  }
+
+  private formatEth(value: number): string {
+    return this.round12(value).toFixed(12);
+  }
+
+  private async invalidateCaches(): Promise<void> {
+    await Promise.all([
+      this.cache.del(REPORT_KEY),
+      this.cache.del(LP_ANALYTICS_KEY),
+    ]);
   }
 
   private toMarketLiquidity(m: Market): MarketLiquidity {

--- a/Backend/src/trading-history/dto/trading-history.dto.ts
+++ b/Backend/src/trading-history/dto/trading-history.dto.ts
@@ -3,26 +3,35 @@ import {
   IsOptional,
   IsDateString,
   IsEnum,
+  IsNumber,
   Min,
-  Max,
 } from 'class-validator';
-import { TradeType, TradeStatus } from '../trading-history.entity';
+import { Type } from 'class-transformer';
+
+const TRADE_TYPES = ['buy', 'sell', 'redeem', 'deposit', 'withdraw'] as const;
+const TRADE_STATUSES = ['pending', 'confirmed', 'failed'] as const;
+type TradeType = (typeof TRADE_TYPES)[number];
+type TradeStatus = (typeof TRADE_STATUSES)[number];
 
 export class GetTradingHistoryDto {
   @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   @Min(1)
   limit?: number = 20;
 
   @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   @Min(0)
   offset?: number = 0;
 
   @IsOptional()
-  @IsEnum(['buy', 'sell', 'redeem', 'deposit', 'withdraw'])
+  @IsEnum(TRADE_TYPES)
   type?: TradeType;
 
   @IsOptional()
-  @IsEnum(['pending', 'confirmed', 'failed'])
+  @IsEnum(TRADE_STATUSES)
   status?: TradeStatus;
 
   @IsOptional()
@@ -52,7 +61,7 @@ export class ExportTradingHistoryDto {
   format?: 'csv' | 'json' = 'csv';
 
   @IsOptional()
-  @IsEnum(['buy', 'sell', 'redeem', 'deposit', 'withdraw'])
+  @IsEnum(TRADE_TYPES)
   type?: TradeType;
 
   @IsOptional()

--- a/Backend/src/trading-history/trading-history.service.ts
+++ b/Backend/src/trading-history/trading-history.service.ts
@@ -21,6 +21,9 @@ export class TradingHistoryService {
   }
 
   getTradingHistory(userId: string, dto: GetTradingHistoryDto) {
+    const limit = dto.limit ?? 20;
+    const offset = dto.offset ?? 0;
+
     let userTrades = [...this.trades.values()].filter(
       (t) => t.userId === userId,
     );
@@ -64,12 +67,12 @@ export class TradingHistoryService {
 
     // Apply pagination
     const total = userTrades.length;
-    const paginated = userTrades.slice(dto.offset, dto.offset + dto.limit);
+    const paginated = userTrades.slice(offset, offset + limit);
 
     return {
       total,
-      offset: dto.offset,
-      limit: dto.limit,
+      offset,
+      limit,
       data: paginated,
     };
   }

--- a/Backend/src/user-settings/dto/user-settings.dto.ts
+++ b/Backend/src/user-settings/dto/user-settings.dto.ts
@@ -7,7 +7,7 @@ import {
   IsDefined,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { SettingCategory } from '../user-settings.entity';
+import type { SettingCategory } from '../user-settings.entity';
 
 const VALID_CATEGORIES: SettingCategory[] = [
   'notifications',

--- a/Backend/src/user-settings/user-settings.controller.ts
+++ b/Backend/src/user-settings/user-settings.controller.ts
@@ -14,7 +14,7 @@ import {
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UserSettingsService } from './user-settings.service';
-import { SettingCategory } from './user-settings.entity';
+import type { SettingCategory } from './user-settings.entity';
 import {
   UpdateSettingDto,
   UpdateCategoryDto,

--- a/Backend/src/webhooks/webhook.service.ts
+++ b/Backend/src/webhooks/webhook.service.ts
@@ -114,7 +114,7 @@ export class WebhookService {
     return Array.from(this.webhookStatuses.values());
   }
 
-  retryWebhook(eventId: string): WebhookStatus {
+  async retryWebhook(eventId: string): Promise<WebhookStatus> {
     const event = this.webhookEvents.get(eventId);
     if (!event) {
       throw new BadRequestException('Webhook event not found');


### PR DESCRIPTION
Closes #166

## Summary
- Added an LP-focused liquidity provision service covering position tracking, rewards/fees accrual, add/remove liquidity flows, analytics reporting, and automated liquidity management hooks.
- Extended liquidity API routes with authenticated endpoints for provision lifecycle, analytics, and automation configuration/execution.
- Added unit tests for LP lifecycle, rewards/fees accrual, analytics output, and automation behavior.

## Implementation Notes
- Uses `web3` wallet validation/checksum normalization for provider addresses.
- Uses `mathjs` for deterministic fee/reward and share calculations.
- Retains and coexists with existing market-level liquidity report/depth/health methods.

## Additional Build Stabilization
- Fixed pre-existing TypeScript issues in AI caching, category traversal typing, trading-history DTO/service typing, user-settings type imports, and webhook retry async return so backend build compiles cleanly under current tsconfig strictness.