### PR TITLE
[170] [Backend] Implement withdrawal processing

### DIFF
--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { ApprovalModule } from './approval/approval.module';
 import { createKeyv } from '@keyv/redis';
 import { CategoriesModule } from './categories/categories.module';
 import { TradingPairModule } from './trading-pairs/trading-pair.module';
+import { WithdrawalModule } from './withdrawal/withdrawal.module';
 
 @Module({
   imports: [
@@ -85,6 +86,7 @@ import { TradingPairModule } from './trading-pairs/trading-pair.module';
     ApprovalModule,
     CategoriesModule,
     TradingPairModule,
+    WithdrawalModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/Backend/src/withdrawal/dto/withdrawal.dto.ts
+++ b/Backend/src/withdrawal/dto/withdrawal.dto.ts
@@ -1,0 +1,70 @@
+import {
+  IsEthereumAddress,
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsNumberString,
+  IsArray,
+  ArrayMinSize,
+  ArrayMaxSize,
+  IsInt,
+  Min,
+} from 'class-validator';
+
+export class InitiateWithdrawalDto {
+  @IsEthereumAddress()
+  fromAddress: string;
+
+  @IsEthereumAddress()
+  toAddress: string;
+
+  /**
+   * Token contract address, or the sentinel string "NATIVE" for the native
+   * chain token (ETH, MNT, …).
+   */
+  @IsString()
+  @IsNotEmpty()
+  tokenAddress: string;
+
+  @IsNumberString()
+  @IsNotEmpty()
+  amount: string;
+
+  /**
+   * Optional: when provided the withdrawal will be placed under a multi-sig
+   * flow with this threshold.
+   */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  multiSigThreshold?: number;
+
+  /** Required when multiSigThreshold > 0 */
+  @IsOptional()
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(20)
+  @IsEthereumAddress({ each: true })
+  multiSigSigners?: string[];
+}
+
+export class SubmitWithdrawalTxHashDto {
+  @IsString()
+  @IsNotEmpty()
+  txHash: string;
+}
+
+export class MultiSigSignatureDto {
+  @IsEthereumAddress()
+  signerAddress: string;
+
+  @IsString()
+  @IsNotEmpty()
+  signature: string;
+}
+
+export class WithdrawalQueryDto {
+  @IsOptional()
+  @IsString()
+  status?: string;
+}

--- a/Backend/src/withdrawal/withdrawal.controller.ts
+++ b/Backend/src/withdrawal/withdrawal.controller.ts
@@ -1,0 +1,122 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  Request,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { WithdrawalService } from './withdrawal.service';
+import {
+  InitiateWithdrawalDto,
+  SubmitWithdrawalTxHashDto,
+  MultiSigSignatureDto,
+  WithdrawalQueryDto,
+} from './dto/withdrawal.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('withdrawals')
+@UseGuards(JwtAuthGuard)
+export class WithdrawalController {
+  constructor(private readonly withdrawalService: WithdrawalService) {}
+
+  /**
+   * POST /withdrawals
+   * Validate and create a new withdrawal request.
+   * Returns unsigned tx data for the client to broadcast.
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  initiate(
+    @Request() req: { user: { userId: string } },
+    @Body() dto: InitiateWithdrawalDto,
+  ) {
+    return this.withdrawalService.initiateWithdrawal(req.user.userId, dto);
+  }
+
+  /**
+   * GET /withdrawals
+   * List all withdrawals for the authenticated user, optionally filtered by status.
+   */
+  @Get()
+  list(
+    @Request() req: { user: { userId: string } },
+    @Query() query: WithdrawalQueryDto,
+  ) {
+    return this.withdrawalService.listWithdrawals(req.user.userId, query);
+  }
+
+  /**
+   * GET /withdrawals/:id
+   * Get current status of a withdrawal, refreshing on-chain confirmations if needed.
+   */
+  @Get(':id')
+  getStatus(
+    @Request() req: { user: { userId: string } },
+    @Param('id') id: string,
+  ) {
+    return this.withdrawalService.getStatus(id, req.user.userId);
+  }
+
+  /**
+   * PATCH /withdrawals/:id/submit
+   * Submit the on-chain tx hash after the client has broadcast the transaction.
+   */
+  @Patch(':id/submit')
+  submitTxHash(
+    @Request() req: { user: { userId: string } },
+    @Param('id') id: string,
+    @Body() dto: SubmitWithdrawalTxHashDto,
+  ) {
+    return this.withdrawalService.submitTxHash(id, req.user.userId, dto);
+  }
+
+  /**
+   * DELETE /withdrawals/:id
+   * Cancel a withdrawal that is still in 'pending' state (not yet submitted on-chain).
+   */
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  cancel(
+    @Request() req: { user: { userId: string } },
+    @Param('id') id: string,
+  ) {
+    return this.withdrawalService.cancelWithdrawal(id, req.user.userId);
+  }
+
+  /**
+   * POST /withdrawals/:id/signatures
+   * Add a signer's signature for a multi-sig withdrawal.
+   */
+  @Post(':id/signatures')
+  @HttpCode(HttpStatus.OK)
+  addSignature(
+    @Request() req: { user: { userId: string } },
+    @Param('id') id: string,
+    @Body() dto: MultiSigSignatureDto,
+  ) {
+    return this.withdrawalService.addMultiSigSignature(
+      id,
+      req.user.userId,
+      dto,
+    );
+  }
+
+  /**
+   * GET /withdrawals/:id/multisig
+   * Get current multi-sig status for a withdrawal.
+   */
+  @Get(':id/multisig')
+  getMultiSig(
+    @Request() req: { user: { userId: string } },
+    @Param('id') id: string,
+  ) {
+    return this.withdrawalService.getMultiSigStatus(id, req.user.userId);
+  }
+}

--- a/Backend/src/withdrawal/withdrawal.entity.ts
+++ b/Backend/src/withdrawal/withdrawal.entity.ts
@@ -1,0 +1,39 @@
+export type WithdrawalStatus =
+  | 'pending'
+  | 'submitted'
+  | 'confirmed'
+  | 'failed'
+  | 'cancelled';
+
+export interface WithdrawalRecord {
+  id: string;
+  userId: string;
+  fromAddress: string;
+  toAddress: string;
+  /** token address, or 'NATIVE' for ETH/native token */
+  tokenAddress: string;
+  /** amount in the smallest unit (wei for ETH, base units for ERC-20) */
+  amount: string;
+  txHash?: string;
+  status: WithdrawalStatus;
+  confirmations: number;
+  requiredConfirmations: number;
+  blockNumber?: number;
+  /** present when multi-sig is enabled */
+  multiSigId?: string;
+  failureReason?: string;
+  createdAt: Date;
+  submittedAt?: Date;
+  confirmedAt?: Date;
+}
+
+export interface MultiSigWithdrawal {
+  id: string;
+  withdrawalId: string;
+  threshold: number;
+  signers: string[]; // checksummed addresses
+  signatures: Record<string, string>; // signer → signature
+  status: 'pending' | 'ready' | 'executed' | 'rejected';
+  createdAt: Date;
+  executedAt?: Date;
+}

--- a/Backend/src/withdrawal/withdrawal.module.ts
+++ b/Backend/src/withdrawal/withdrawal.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { WithdrawalController } from './withdrawal.controller';
+import { WithdrawalService } from './withdrawal.service';
+
+@Module({
+  controllers: [WithdrawalController],
+  providers: [WithdrawalService],
+  exports: [WithdrawalService],
+})
+export class WithdrawalModule {}

--- a/Backend/src/withdrawal/withdrawal.service.spec.ts
+++ b/Backend/src/withdrawal/withdrawal.service.spec.ts
@@ -1,0 +1,370 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { WithdrawalService } from './withdrawal.service';
+import { ethers } from 'ethers';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function mockConfigService(overrides: Record<string, string> = {}): Partial<ConfigService> {
+  return {
+    get: jest.fn((key: string, def?: unknown) => overrides[key] ?? def),
+  };
+}
+
+/** Produce a real 65-byte personal-sign signature for `msg` using `wallet`. */
+async function sign(wallet: { signMessage(msg: string): Promise<string> }, msg: string): Promise<string> {
+  return wallet.signMessage(msg);
+}
+
+const AMOUNT = '1000000000000000000'; // 1 ETH in wei
+const USER_ID = 'user-abc';
+const OTHER_USER = 'user-xyz';
+
+// Use real deterministic wallets so checksum addresses are always valid.
+const walletA = ethers.Wallet.createRandom();
+const walletB = ethers.Wallet.createRandom();
+const walletC = ethers.Wallet.createRandom();
+
+const FROM = walletA.address; // checksummed
+const TO = walletB.address;
+const TOKEN = '0x' + '1'.repeat(40); // valid-looking ERC-20 address
+
+// ── test suite ────────────────────────────────────────────────────────────────
+
+describe('WithdrawalService', () => {
+  let service: WithdrawalService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WithdrawalService,
+        { provide: ConfigService, useValue: mockConfigService() },
+      ],
+    }).compile();
+
+    service = module.get<WithdrawalService>(WithdrawalService);
+  });
+
+  // ── initiation ────────────────────────────────────────────────────────────
+
+  describe('initiateWithdrawal', () => {
+    it('should create a pending withdrawal record for native transfer', () => {
+      const result = service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+
+      expect(result.withdrawalId).toBeDefined();
+      expect(result.record.status).toBe('pending');
+      expect(result.record.tokenAddress).toBe('NATIVE');
+      expect(result.txData).toMatchObject({ from: FROM, to: TO });
+    });
+
+    it('should create a pending withdrawal record for ERC-20 transfer', () => {
+      const result = service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: TOKEN,
+        amount: AMOUNT,
+      });
+
+      expect(result.record.tokenAddress).toBe(ethers.getAddress(TOKEN));
+      const tx = result.txData as { to: string; data: string };
+      expect(tx.to).toBe(ethers.getAddress(TOKEN));
+      expect(tx.data).toMatch(/^0x/);
+    });
+
+    it('should reject self-transfers', () => {
+      expect(() =>
+        service.initiateWithdrawal(USER_ID, {
+          fromAddress: FROM,
+          toAddress: FROM,
+          tokenAddress: 'NATIVE',
+          amount: AMOUNT,
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should reject zero or negative amounts', () => {
+      expect(() =>
+        service.initiateWithdrawal(USER_ID, {
+          fromAddress: FROM,
+          toAddress: TO,
+          tokenAddress: 'NATIVE',
+          amount: '0',
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should reject non-numeric amounts', () => {
+      expect(() =>
+        service.initiateWithdrawal(USER_ID, {
+          fromAddress: FROM,
+          toAddress: TO,
+          tokenAddress: 'NATIVE',
+          amount: 'not-a-number',
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should reject invalid from-address', () => {
+      expect(() =>
+        service.initiateWithdrawal(USER_ID, {
+          fromAddress: 'bad-address',
+          toAddress: TO,
+          tokenAddress: 'NATIVE',
+          amount: AMOUNT,
+        }),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  // ── listing ───────────────────────────────────────────────────────────────
+
+  describe('listWithdrawals', () => {
+    it('should return only withdrawals belonging to the user', () => {
+      service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+      service.initiateWithdrawal(OTHER_USER, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+
+      const list = service.listWithdrawals(USER_ID, {});
+      expect(list).toHaveLength(1);
+      expect(list[0].userId).toBe(USER_ID);
+    });
+
+    it('should filter by status when provided', () => {
+      service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+
+      const pending = service.listWithdrawals(USER_ID, { status: 'pending' });
+      const confirmed = service.listWithdrawals(USER_ID, { status: 'confirmed' });
+      expect(pending).toHaveLength(1);
+      expect(confirmed).toHaveLength(0);
+    });
+  });
+
+  // ── cancellation ──────────────────────────────────────────────────────────
+
+  describe('cancelWithdrawal', () => {
+    it('should cancel a pending withdrawal', () => {
+      const { withdrawalId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+
+      const cancelled = service.cancelWithdrawal(withdrawalId, USER_ID);
+      expect(cancelled.status).toBe('cancelled');
+    });
+
+    it('should throw when another user tries to cancel', () => {
+      const { withdrawalId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+
+      expect(() =>
+        service.cancelWithdrawal(withdrawalId, OTHER_USER),
+      ).toThrow(ForbiddenException);
+    });
+
+    it('should throw when cancelling an already cancelled withdrawal', () => {
+      const { withdrawalId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+      service.cancelWithdrawal(withdrawalId, USER_ID);
+
+      expect(() =>
+        service.cancelWithdrawal(withdrawalId, USER_ID),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should throw when withdrawal id does not exist', () => {
+      expect(() =>
+        service.cancelWithdrawal('non-existent-id', USER_ID),
+      ).toThrow(NotFoundException);
+    });
+  });
+
+  // ── tx hash submission ────────────────────────────────────────────────────
+
+  describe('submitTxHash', () => {
+    it('should update status to submitted and set txHash', async () => {
+      const { withdrawalId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+
+      // Mock provider so trackConfirmations doesn't resolve synchronously and
+      // overwrite the 'submitted' status before the assertion runs.
+      (service as any).provider = {
+        waitForTransaction: jest.fn().mockReturnValue(new Promise(() => {})),
+      };
+
+      const updated = await service.submitTxHash(withdrawalId, USER_ID, {
+        txHash: '0x' + 'a'.repeat(64),
+      });
+
+      expect(updated.status).toBe('submitted');
+      expect(updated.txHash).toBe('0x' + 'a'.repeat(64));
+    });
+
+    it('should throw when the withdrawal is not in pending state', async () => {
+      const { withdrawalId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: FROM,
+        toAddress: TO,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+      });
+      service.cancelWithdrawal(withdrawalId, USER_ID);
+
+      await expect(
+        service.submitTxHash(withdrawalId, USER_ID, {
+          txHash: '0x' + 'b'.repeat(64),
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── multi-sig ─────────────────────────────────────────────────────────────
+
+  describe('multi-sig withdrawals', () => {
+    it('should create a multi-sig record and require threshold signatures before submission', async () => {
+      const signers = [walletA.address, walletB.address, walletC.address];
+
+      const { withdrawalId, multiSigId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: walletA.address,
+        toAddress: walletB.address,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+        multiSigThreshold: 2,
+        multiSigSigners: signers,
+      });
+
+      expect(multiSigId).toBeDefined();
+
+      // Only one signature so far — should NOT be ready
+      const sigA = await sign(walletA, `GateDelay withdrawal ${withdrawalId}`);
+      const msAfterFirst = service.addMultiSigSignature(
+        withdrawalId,
+        USER_ID,
+        { signerAddress: walletA.address, signature: sigA },
+      );
+      expect(msAfterFirst.status).toBe('pending');
+
+      // Second signature — threshold reached → ready
+      const sigB = await sign(walletB, `GateDelay withdrawal ${withdrawalId}`);
+      const msAfterSecond = service.addMultiSigSignature(
+        withdrawalId,
+        USER_ID,
+        { signerAddress: walletB.address, signature: sigB },
+      );
+      expect(msAfterSecond.status).toBe('ready');
+    });
+
+    it('should block submission when multi-sig threshold not yet reached', async () => {
+      const signers = [walletA.address, walletB.address];
+
+      const { withdrawalId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: walletA.address,
+        toAddress: walletC.address,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+        multiSigThreshold: 2,
+        multiSigSigners: signers,
+      });
+
+      await expect(
+        service.submitTxHash(withdrawalId, USER_ID, {
+          txHash: '0x' + 'c'.repeat(64),
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject a duplicate signature from the same signer', async () => {
+      const signers = [walletA.address, walletB.address];
+
+      const { withdrawalId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: walletA.address,
+        toAddress: walletC.address,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+        multiSigThreshold: 2,
+        multiSigSigners: signers,
+      });
+
+      const sigA = await sign(walletA, `GateDelay withdrawal ${withdrawalId}`);
+      service.addMultiSigSignature(withdrawalId, USER_ID, {
+        signerAddress: walletA.address,
+        signature: sigA,
+      });
+
+      // Same signer again
+      expect(() =>
+        service.addMultiSigSignature(withdrawalId, USER_ID, {
+          signerAddress: walletA.address,
+          signature: sigA,
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should reject a signature from an address that is not a registered signer', async () => {
+      const nonSigner = ethers.Wallet.createRandom();
+      const signers = [walletA.address, walletB.address];
+
+      const { withdrawalId } = service.initiateWithdrawal(USER_ID, {
+        fromAddress: walletA.address,
+        toAddress: walletC.address,
+        tokenAddress: 'NATIVE',
+        amount: AMOUNT,
+        multiSigThreshold: 2,
+        multiSigSigners: signers,
+      });
+
+      const sig = await sign(nonSigner, `GateDelay withdrawal ${withdrawalId}`);
+      expect(() =>
+        service.addMultiSigSignature(withdrawalId, USER_ID, {
+          signerAddress: nonSigner.address,
+          signature: sig,
+        }),
+      ).toThrow(ForbiddenException);
+    });
+
+    it('should reject when threshold exceeds number of signers', () => {
+      expect(() =>
+        service.initiateWithdrawal(USER_ID, {
+          fromAddress: walletA.address,
+          toAddress: walletC.address,
+          tokenAddress: 'NATIVE',
+          amount: AMOUNT,
+          multiSigThreshold: 3,
+          multiSigSigners: [walletA.address, walletB.address],
+        }),
+      ).toThrow(BadRequestException);
+    });
+  });
+});

--- a/Backend/src/withdrawal/withdrawal.service.ts
+++ b/Backend/src/withdrawal/withdrawal.service.ts
@@ -1,0 +1,471 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ethers } from 'ethers';
+import { randomUUID } from 'crypto';
+import {
+  WithdrawalRecord,
+  WithdrawalStatus,
+  MultiSigWithdrawal,
+} from './withdrawal.entity';
+import {
+  InitiateWithdrawalDto,
+  SubmitWithdrawalTxHashDto,
+  MultiSigSignatureDto,
+  WithdrawalQueryDto,
+} from './dto/withdrawal.dto';
+
+const ERC20_TRANSFER_ABI = [
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'function balanceOf(address account) view returns (uint256)',
+];
+
+const NATIVE_SENTINEL = 'NATIVE';
+const DEFAULT_REQUIRED_CONFIRMATIONS = 12;
+
+@Injectable()
+export class WithdrawalService {
+  private readonly logger = new Logger(WithdrawalService.name);
+  private readonly withdrawals = new Map<string, WithdrawalRecord>();
+  private readonly multiSigs = new Map<string, MultiSigWithdrawal>();
+  private readonly provider: ethers.JsonRpcProvider;
+
+  constructor(private readonly config: ConfigService) {
+    const rpcUrl = this.config.get<string>(
+      'BLOCKCHAIN_RPC_URL',
+      'https://rpc.mantle.xyz',
+    );
+    this.provider = new ethers.JsonRpcProvider(rpcUrl);
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /**
+   * Validate and register a new withdrawal request.
+   * Returns the unsigned transaction payload for the client to broadcast,
+   * along with the created withdrawal record.
+   */
+  initiateWithdrawal(
+    userId: string,
+    dto: InitiateWithdrawalDto,
+  ): {
+    withdrawalId: string;
+    txData: object | null;
+    multiSigId?: string;
+    record: WithdrawalRecord;
+  } {
+    const fromAddress = this.checksumAddress(dto.fromAddress);
+    const toAddress = this.checksumAddress(dto.toAddress);
+    const isNative =
+      dto.tokenAddress.toUpperCase() === NATIVE_SENTINEL.toUpperCase();
+    const tokenAddress = isNative
+      ? NATIVE_SENTINEL
+      : this.checksumAddress(dto.tokenAddress);
+
+    this.validateAmount(dto.amount);
+    this.validateSelfTransfer(fromAddress, toAddress);
+
+    const hasMultiSig =
+      dto.multiSigThreshold != null &&
+      dto.multiSigThreshold > 0 &&
+      dto.multiSigSigners?.length;
+
+    if (hasMultiSig) {
+      const signers = dto.multiSigSigners!.map((s) => this.checksumAddress(s));
+      if (!signers.includes(fromAddress)) {
+        throw new BadRequestException(
+          'fromAddress must be one of the multiSigSigners',
+        );
+      }
+      if (dto.multiSigThreshold! > signers.length) {
+        throw new BadRequestException(
+          'multiSigThreshold cannot exceed the number of signers',
+        );
+      }
+    }
+
+    const record: WithdrawalRecord = {
+      id: randomUUID(),
+      userId,
+      fromAddress,
+      toAddress,
+      tokenAddress,
+      amount: dto.amount,
+      status: 'pending',
+      confirmations: 0,
+      requiredConfirmations: DEFAULT_REQUIRED_CONFIRMATIONS,
+      createdAt: new Date(),
+    };
+
+    let multiSigId: string | undefined;
+
+    if (hasMultiSig) {
+      const signers = dto.multiSigSigners!.map((s) => this.checksumAddress(s));
+      const multiSig: MultiSigWithdrawal = {
+        id: randomUUID(),
+        withdrawalId: record.id,
+        threshold: dto.multiSigThreshold!,
+        signers,
+        signatures: {},
+        status: 'pending',
+        createdAt: new Date(),
+      };
+      this.multiSigs.set(multiSig.id, multiSig);
+      record.multiSigId = multiSig.id;
+      multiSigId = multiSig.id;
+    }
+
+    const txData = this.buildTxData(
+      fromAddress,
+      toAddress,
+      tokenAddress,
+      dto.amount,
+      isNative,
+    );
+
+    this.withdrawals.set(record.id, record);
+    this.logger.log(
+      `Withdrawal ${record.id} initiated by user ${userId} [${dto.amount} ${tokenAddress}]`,
+    );
+
+    return { withdrawalId: record.id, txData, multiSigId, record };
+  }
+
+  /**
+   * Submit the on-chain tx hash once the client has broadcast the transaction.
+   * Starts asynchronous confirmation tracking.
+   */
+  async submitTxHash(
+    withdrawalId: string,
+    userId: string,
+    dto: SubmitWithdrawalTxHashDto,
+  ): Promise<WithdrawalRecord> {
+    const record = this.getWithdrawalOrThrow(withdrawalId);
+    this.assertOwner(record, userId);
+
+    if (record.status !== 'pending') {
+      throw new BadRequestException(
+        `Withdrawal ${withdrawalId} is already ${record.status}`,
+      );
+    }
+
+    if (record.multiSigId) {
+      const ms = this.multiSigs.get(record.multiSigId);
+      if (ms && ms.status !== 'ready' && ms.status !== 'executed') {
+        throw new BadRequestException(
+          'Multi-sig threshold has not been reached yet — collect all required signatures first',
+        );
+      }
+    }
+
+    record.txHash = dto.txHash;
+    record.status = 'submitted';
+    record.submittedAt = new Date();
+    this.withdrawals.set(withdrawalId, record);
+
+    // fire-and-forget confirmation tracking
+    this.trackConfirmations(withdrawalId, dto.txHash).catch((err) =>
+      this.logger.error(`Confirmation tracking failed for ${withdrawalId}`, err),
+    );
+
+    return record;
+  }
+
+  /**
+   * Return current status of a withdrawal, refreshing on-chain state when
+   * a tx hash is present but not yet confirmed.
+   */
+  async getStatus(
+    withdrawalId: string,
+    userId: string,
+  ): Promise<WithdrawalRecord> {
+    const record = this.getWithdrawalOrThrow(withdrawalId);
+    this.assertOwner(record, userId);
+
+    if (
+      record.txHash &&
+      record.status !== 'confirmed' &&
+      record.status !== 'failed'
+    ) {
+      await this.refreshConfirmations(record);
+    }
+
+    return record;
+  }
+
+  /** List all withdrawals for the authenticated user, optionally filtered by status. */
+  listWithdrawals(userId: string, query: WithdrawalQueryDto): WithdrawalRecord[] {
+    let results = [...this.withdrawals.values()].filter(
+      (w) => w.userId === userId,
+    );
+
+    if (query.status) {
+      const normalised = query.status.toLowerCase() as WithdrawalStatus;
+      results = results.filter((w) => w.status === normalised);
+    }
+
+    return results.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  }
+
+  /** Cancel a pending withdrawal that has not yet been submitted on-chain. */
+  cancelWithdrawal(withdrawalId: string, userId: string): WithdrawalRecord {
+    const record = this.getWithdrawalOrThrow(withdrawalId);
+    this.assertOwner(record, userId);
+
+    if (record.status !== 'pending') {
+      throw new BadRequestException(
+        `Only pending withdrawals can be cancelled; current status: ${record.status}`,
+      );
+    }
+
+    record.status = 'cancelled';
+    this.withdrawals.set(withdrawalId, record);
+    this.logger.log(`Withdrawal ${withdrawalId} cancelled by user ${userId}`);
+    return record;
+  }
+
+  // ── Multi-sig ──────────────────────────────────────────────────────────────
+
+  /** Add one signer's signature. Once threshold is reached, status flips to 'ready'. */
+  addMultiSigSignature(
+    withdrawalId: string,
+    userId: string,
+    dto: MultiSigSignatureDto,
+  ): MultiSigWithdrawal {
+    const record = this.getWithdrawalOrThrow(withdrawalId);
+    this.assertOwner(record, userId);
+
+    if (!record.multiSigId) {
+      throw new BadRequestException(
+        `Withdrawal ${withdrawalId} is not a multi-sig withdrawal`,
+      );
+    }
+
+    const ms = this.multiSigs.get(record.multiSigId);
+    if (!ms) {
+      throw new NotFoundException(
+        `MultiSig record ${record.multiSigId} not found`,
+      );
+    }
+
+    if (ms.status === 'executed' || ms.status === 'rejected') {
+      throw new BadRequestException(`MultiSig is already ${ms.status}`);
+    }
+
+    const signerAddress = this.checksumAddress(dto.signerAddress);
+
+    if (!ms.signers.includes(signerAddress)) {
+      throw new ForbiddenException(
+        `${signerAddress} is not a registered signer for this multi-sig`,
+      );
+    }
+
+    if (ms.signatures[signerAddress]) {
+      throw new BadRequestException(
+        `Signature from ${signerAddress} already recorded`,
+      );
+    }
+
+    // Verify the signer actually signed the withdrawal id
+    this.verifyMultiSigSignature(withdrawalId, dto.signature, signerAddress);
+
+    ms.signatures[signerAddress] = dto.signature;
+
+    const collectedCount = Object.keys(ms.signatures).length;
+    if (collectedCount >= ms.threshold) {
+      ms.status = 'ready';
+      this.logger.log(
+        `MultiSig ${ms.id} reached threshold (${collectedCount}/${ms.threshold}) — withdrawal ${withdrawalId} is ready`,
+      );
+    }
+
+    this.multiSigs.set(ms.id, ms);
+    return ms;
+  }
+
+  getMultiSigStatus(
+    withdrawalId: string,
+    userId: string,
+  ): MultiSigWithdrawal & { signaturesCollected: number } {
+    const record = this.getWithdrawalOrThrow(withdrawalId);
+    this.assertOwner(record, userId);
+
+    if (!record.multiSigId) {
+      throw new BadRequestException(
+        `Withdrawal ${withdrawalId} is not a multi-sig withdrawal`,
+      );
+    }
+
+    const ms = this.multiSigs.get(record.multiSigId);
+    if (!ms) {
+      throw new NotFoundException(`MultiSig ${record.multiSigId} not found`);
+    }
+
+    return { ...ms, signaturesCollected: Object.keys(ms.signatures).length };
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private buildTxData(
+    from: string,
+    to: string,
+    tokenAddress: string,
+    amount: string,
+    isNative: boolean,
+  ): object | null {
+    if (isNative) {
+      return {
+        from,
+        to,
+        value: `0x${BigInt(amount).toString(16)}`,
+      };
+    }
+
+    try {
+      const iface = new ethers.Interface(ERC20_TRANSFER_ABI);
+      const data = iface.encodeFunctionData('transfer', [to, BigInt(amount)]);
+      return { from, to: tokenAddress, data, value: '0x0' };
+    } catch {
+      // if encoding fails due to bad inputs, surface at service boundary
+      throw new BadRequestException('Failed to encode ERC-20 transfer calldata');
+    }
+  }
+
+  private async trackConfirmations(
+    withdrawalId: string,
+    txHash: string,
+  ): Promise<void> {
+    const record = this.withdrawals.get(withdrawalId);
+    if (!record) return;
+
+    try {
+      const receipt = await this.provider.waitForTransaction(
+        txHash,
+        record.requiredConfirmations,
+      );
+
+      if (!receipt) {
+        record.status = 'failed';
+        record.failureReason = 'Transaction not found on-chain';
+        this.withdrawals.set(withdrawalId, record);
+        return;
+      }
+
+      if (receipt.status === 0) {
+        record.status = 'failed';
+        record.failureReason = 'Transaction reverted on-chain';
+      } else {
+        record.status = 'confirmed';
+        record.confirmations = record.requiredConfirmations;
+        record.blockNumber = receipt.blockNumber;
+        record.confirmedAt = new Date();
+      }
+
+      this.withdrawals.set(withdrawalId, record);
+      this.logger.log(
+        `Withdrawal ${withdrawalId} status updated to ${record.status}`,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Error tracking confirmations for ${withdrawalId}`,
+        err,
+      );
+      record.status = 'failed';
+      record.failureReason =
+        err instanceof Error ? err.message : 'Unknown error';
+      this.withdrawals.set(withdrawalId, record);
+    }
+  }
+
+  private async refreshConfirmations(record: WithdrawalRecord): Promise<void> {
+    if (!record.txHash) return;
+
+    try {
+      const receipt = await this.provider.getTransactionReceipt(record.txHash);
+      if (!receipt) return;
+
+      const currentBlock = await this.provider.getBlockNumber();
+      const confirmations = currentBlock - receipt.blockNumber + 1;
+      record.confirmations = Math.max(0, confirmations);
+      record.blockNumber = receipt.blockNumber;
+
+      if (receipt.status === 0) {
+        record.status = 'failed';
+        record.failureReason = 'Transaction reverted on-chain';
+      } else if (record.confirmations >= record.requiredConfirmations) {
+        record.status = 'confirmed';
+        record.confirmedAt = record.confirmedAt ?? new Date();
+      }
+
+      this.withdrawals.set(record.id, record);
+    } catch (err) {
+      this.logger.warn(
+        `Could not refresh confirmations for ${record.id}: ${err}`,
+      );
+    }
+  }
+
+  private verifyMultiSigSignature(
+    withdrawalId: string,
+    signature: string,
+    expectedSigner: string,
+  ): void {
+    try {
+      const message = `GateDelay withdrawal ${withdrawalId}`;
+      const recovered = ethers.verifyMessage(message, signature);
+      if (recovered.toLowerCase() !== expectedSigner.toLowerCase()) {
+        throw new BadRequestException(
+          `Signature does not match signer ${expectedSigner}`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new BadRequestException('Invalid signature format');
+    }
+  }
+
+  private checksumAddress(address: string): string {
+    try {
+      return ethers.getAddress(address);
+    } catch {
+      throw new BadRequestException(`Invalid Ethereum address: ${address}`);
+    }
+  }
+
+  private validateAmount(amount: string): void {
+    try {
+      const parsed = BigInt(amount);
+      if (parsed <= 0n) {
+        throw new BadRequestException('Amount must be greater than zero');
+      }
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new BadRequestException('Amount must be a valid positive integer string (in smallest unit)');
+    }
+  }
+
+  private validateSelfTransfer(from: string, to: string): void {
+    if (from.toLowerCase() === to.toLowerCase()) {
+      throw new BadRequestException('fromAddress and toAddress must differ');
+    }
+  }
+
+  private getWithdrawalOrThrow(withdrawalId: string): WithdrawalRecord {
+    const record = this.withdrawals.get(withdrawalId);
+    if (!record) {
+      throw new NotFoundException(`Withdrawal ${withdrawalId} not found`);
+    }
+    return record;
+  }
+
+  private assertOwner(record: WithdrawalRecord, userId: string): void {
+    if (record.userId !== userId) {
+      throw new ForbiddenException('Access denied');
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements a secure, end-to-end withdrawal processing system for the GateDelay backend as required by issue #170.

## Changes

### New module: `Backend/src/withdrawal/`

| File | Purpose |
|---|---|
| `withdrawal.entity.ts` | `WithdrawalRecord` and `MultiSigWithdrawal` type definitions |
| `dto/withdrawal.dto.ts` | Validated request DTOs (class-validator decorators) |
| `withdrawal.service.ts` | Core business logic |
| `withdrawal.controller.ts` | REST controller under `/withdrawals` |
| `withdrawal.module.ts` | NestJS module wiring |
| `withdrawal.service.spec.ts` | 19 unit tests (all passing) |

### Modified

- `app.module.ts` — registers `WithdrawalModule`

## API Endpoints

| Method | Path | Description |
|---|---|---|
| `POST` | `/withdrawals` | Initiate withdrawal; returns unsigned tx payload |
| `GET` | `/withdrawals` | List user withdrawals (filterable by `?status=`) |
| `GET` | `/withdrawals/:id` | Fetch withdrawal status (refreshes on-chain confirmations) |
| `PATCH` | `/withdrawals/:id/submit` | Submit on-chain tx hash; starts confirmation tracking |
| `DELETE` | `/withdrawals/:id` | Cancel a pending withdrawal |
| `POST` | `/withdrawals/:id/signatures` | Add multi-sig signer signature |
| `GET` | `/withdrawals/:id/multisig` | Fetch multi-sig status and collected signatures |

## Acceptance Criteria Coverage

- ✅ **Requests validated securely** — address checksum, positive amounts, self-transfer guard, multi-sig signer membership checks
- ✅ **Processing succeeds reliably** — builds unsigned ERC-20 / native tx calldata; `submitTxHash` triggers async confirmation tracking via `waitForTransaction`
- ✅ **Status tracked accurately** — `pending → submitted → confirmed / failed / cancelled` lifecycle stored in-memory and refreshed on-chain on status queries
- ✅ **Confirmations handled** — `trackConfirmations` polls for `requiredConfirmations` (default 12) and `refreshConfirmations` updates live on GET
- ✅ **Multi-sig works correctly** — threshold + signers configured at initiation; EIP-191 signatures verified with `ethers.verifyMessage`; submission blocked until threshold reached

## Test Results

```
Tests:       19 passed, 19 total
Test Suites: 1 passed, 1 total
```

Closes #170