### PR TITLE
[#167] [Backend] Implement transaction nonce manager

### DIFF
--- a/Backend/src/blockchain/blockchain.controller.ts
+++ b/Backend/src/blockchain/blockchain.controller.ts
@@ -1,21 +1,32 @@
 import {
-  Controller,
-  Post,
-  Get,
   Body,
-  Param,
-  UseGuards,
+  Controller,
+  Get,
   HttpCode,
   HttpStatus,
+  Param,
+  Post,
+  UseGuards,
 } from '@nestjs/common';
-import { BlockchainService } from './blockchain.service';
-import { BroadcastTransactionDto } from './dto/transaction.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { BlockchainService } from './blockchain.service';
+import {
+  CommitNonceDto,
+  FillNonceGapsDto,
+  ReleaseNonceDto,
+  ReserveNonceDto,
+  SyncNonceDto,
+} from './dto/nonce.dto';
+import { BroadcastTransactionDto } from './dto/transaction.dto';
+import { NonceManagerService } from './nonce-manager.service';
 
 @Controller('blockchain')
 @UseGuards(JwtAuthGuard)
 export class BlockchainController {
-  constructor(private readonly blockchainService: BlockchainService) {}
+  constructor(
+    private readonly blockchainService: BlockchainService,
+    private readonly nonceManagerService: NonceManagerService,
+  ) {}
 
   @Post('broadcast')
   @HttpCode(HttpStatus.ACCEPTED)
@@ -26,5 +37,55 @@ export class BlockchainController {
   @Get('tx/:hash')
   getStatus(@Param('hash') hash: string) {
     return this.blockchainService.getTransactionStatus(hash);
+  }
+
+  @Post('nonce/reserve')
+  reserveNonce(@Body() dto: ReserveNonceDto) {
+    return this.nonceManagerService.reserveNonce(
+      dto.address,
+      dto.network,
+      dto.ttlMs,
+    );
+  }
+
+  @Post('nonce/commit')
+  commitNonce(@Body() dto: CommitNonceDto) {
+    return this.nonceManagerService.commitReservation(
+      dto.address,
+      dto.reservationId,
+      dto.network,
+    );
+  }
+
+  @Post('nonce/release')
+  releaseNonce(@Body() dto: ReleaseNonceDto) {
+    return this.nonceManagerService.releaseReservation(
+      dto.address,
+      dto.reservationId,
+      dto.network,
+    );
+  }
+
+  @Post('nonce/sync')
+  syncNonce(@Body() dto: SyncNonceDto) {
+    return this.nonceManagerService.syncNonce(dto.address, dto.network);
+  }
+
+  @Post('nonce/fill-gaps')
+  fillNonceGaps(@Body() dto: FillNonceGapsDto) {
+    return this.nonceManagerService.fillNonceGaps(
+      dto.address,
+      dto.network,
+      dto.reserveFirstGap,
+      dto.ttlMs,
+    );
+  }
+
+  @Get('nonce/:network/:address')
+  getNonceState(
+    @Param('network') network: string,
+    @Param('address') address: string,
+  ) {
+    return this.nonceManagerService.getNonceState(address, network);
   }
 }

--- a/Backend/src/blockchain/blockchain.module.ts
+++ b/Backend/src/blockchain/blockchain.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { BlockchainService } from './blockchain.service';
 import { BlockchainController } from './blockchain.controller';
+import { NonceManagerService } from './nonce-manager.service';
 
 @Module({
   controllers: [BlockchainController],
-  providers: [BlockchainService],
-  exports: [BlockchainService],
+  providers: [BlockchainService, NonceManagerService],
+  exports: [BlockchainService, NonceManagerService],
 })
 export class BlockchainModule {}

--- a/Backend/src/blockchain/dto/nonce.dto.ts
+++ b/Backend/src/blockchain/dto/nonce.dto.ts
@@ -1,0 +1,76 @@
+import {
+  IsBoolean,
+  IsEthereumAddress,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class ReserveNonceDto {
+  @IsEthereumAddress()
+  address: string;
+
+  @IsString()
+  @IsOptional()
+  network?: string;
+
+  @IsInt()
+  @Min(1000)
+  @IsOptional()
+  ttlMs?: number;
+}
+
+export class CommitNonceDto {
+  @IsEthereumAddress()
+  address: string;
+
+  @IsString()
+  @IsOptional()
+  network?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  reservationId: string;
+}
+
+export class ReleaseNonceDto {
+  @IsEthereumAddress()
+  address: string;
+
+  @IsString()
+  @IsOptional()
+  network?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  reservationId: string;
+}
+
+export class SyncNonceDto {
+  @IsEthereumAddress()
+  address: string;
+
+  @IsString()
+  @IsOptional()
+  network?: string;
+}
+
+export class FillNonceGapsDto {
+  @IsEthereumAddress()
+  address: string;
+
+  @IsString()
+  @IsOptional()
+  network?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  reserveFirstGap?: boolean;
+
+  @IsInt()
+  @Min(1000)
+  @IsOptional()
+  ttlMs?: number;
+}

--- a/Backend/src/blockchain/models/nonce.model.ts
+++ b/Backend/src/blockchain/models/nonce.model.ts
@@ -1,0 +1,35 @@
+export interface NonceReservation {
+  reservationId: string;
+  nonce: number;
+  reservedAt: string;
+  expiresAt: string;
+}
+
+export interface NonceState {
+  network: string;
+  address: string;
+  chainNonce: number;
+  nextNonce: number;
+  usedNonces: number[];
+  reservations: Record<string, NonceReservation>;
+  updatedAt: string;
+}
+
+export interface ReserveNonceResult {
+  network: string;
+  address: string;
+  nonce: number;
+  reservationId: string;
+  expiresAt: string;
+  chainNonce: number;
+  nextNonce: number;
+}
+
+export interface GapFillResult {
+  network: string;
+  address: string;
+  chainNonce: number;
+  nextNonce: number;
+  gaps: number[];
+  reserved?: ReserveNonceResult;
+}

--- a/Backend/src/blockchain/nonce-manager.service.spec.ts
+++ b/Backend/src/blockchain/nonce-manager.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { ethers } from 'ethers';
+import { NonceManagerService } from './nonce-manager.service';
+
+describe('NonceManagerService', () => {
+  let service: NonceManagerService;
+
+  const cacheStore = new Map<string, unknown>();
+  const cache = {
+    get: jest.fn(async <T>(key: string): Promise<T | undefined> => {
+      return cacheStore.get(key) as T | undefined;
+    }),
+    set: jest.fn(async (key: string, value: unknown): Promise<void> => {
+      cacheStore.set(key, value);
+    }),
+  };
+
+  const config = {
+    get: jest.fn((key: string, fallback?: string) => {
+      if (key === 'BLOCKCHAIN_RPC_URL') return 'https://rpc.test';
+      return fallback;
+    }),
+  };
+
+  const mockProvider = {
+    getTransactionCount: jest.fn(async () => 10),
+  };
+
+  const testAddress = ethers.Wallet.createRandom().address;
+
+  beforeEach(async () => {
+    cacheStore.clear();
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NonceManagerService,
+        { provide: ConfigService, useValue: config },
+        { provide: CACHE_MANAGER, useValue: cache },
+      ],
+    }).compile();
+
+    service = module.get<NonceManagerService>(NonceManagerService);
+    (service as unknown as { providerCache: Map<string, unknown> }).providerCache.set(
+      'mantle',
+      mockProvider,
+    );
+  });
+
+  it('reserves nonces sequentially and avoids conflicts', async () => {
+    const r1 = await service.reserveNonce(testAddress, 'mantle', 60_000);
+    const r2 = await service.reserveNonce(testAddress, 'mantle', 60_000);
+
+    expect(r1.nonce).toBe(10);
+    expect(r2.nonce).toBe(11);
+    expect(r1.reservationId).not.toBe(r2.reservationId);
+  });
+
+  it('commits reservation and does not reuse committed nonce', async () => {
+    const r1 = await service.reserveNonce(testAddress, 'mantle', 60_000);
+    await service.commitReservation(testAddress, r1.reservationId, 'mantle');
+
+    const r2 = await service.reserveNonce(testAddress, 'mantle', 60_000);
+    expect(r2.nonce).toBe(11);
+  });
+
+  it('fills nonce gaps and can reserve first gap', async () => {
+    const r1 = await service.reserveNonce(testAddress, 'mantle', 60_000);
+    const r2 = await service.reserveNonce(testAddress, 'mantle', 60_000);
+    const r3 = await service.reserveNonce(testAddress, 'mantle', 60_000);
+
+    await service.commitReservation(testAddress, r1.reservationId, 'mantle');
+    await service.commitReservation(testAddress, r3.reservationId, 'mantle');
+    await service.releaseReservation(testAddress, r2.reservationId, 'mantle');
+
+    const result = await service.fillNonceGaps(testAddress, 'mantle', true, 60_000);
+
+    expect(result.reserved).toBeDefined();
+    expect(result.reserved?.nonce).toBe(11);
+    expect(result.gaps).not.toContain(11);
+  });
+
+  it('syncs nonce with chain pending count', async () => {
+    await service.reserveNonce(testAddress, 'mantle', 60_000);
+
+    mockProvider.getTransactionCount.mockResolvedValueOnce(20);
+    const synced = await service.syncNonce(testAddress, 'mantle');
+
+    expect(synced.chainNonce).toBe(20);
+    expect(synced.nextNonce).toBe(20);
+  });
+});

--- a/Backend/src/blockchain/nonce-manager.service.ts
+++ b/Backend/src/blockchain/nonce-manager.service.ts
@@ -1,0 +1,391 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { ethers } from 'ethers';
+import { randomUUID } from 'crypto';
+import {
+  GapFillResult,
+  NonceReservation,
+  NonceState,
+  ReserveNonceResult,
+} from './models/nonce.model';
+
+const DEFAULT_NETWORK = 'mantle';
+const DEFAULT_RESERVATION_TTL_MS = 30_000;
+
+@Injectable()
+export class NonceManagerService {
+  private readonly providerCache = new Map<string, ethers.JsonRpcProvider>();
+  private readonly mutexes = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly config: ConfigService,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+  ) {}
+
+  async getNonceState(
+    address: string,
+    network = DEFAULT_NETWORK,
+  ): Promise<NonceState> {
+    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedNetwork = this.normalizeNetwork(network);
+
+    return this.withLock(normalizedNetwork, normalizedAddress, async () => {
+      const state = await this.getOrInitState(normalizedAddress, normalizedNetwork);
+      await this.pruneExpiredReservations(state);
+      await this.persistState(state);
+      return state;
+    });
+  }
+
+  async reserveNonce(
+    address: string,
+    network = DEFAULT_NETWORK,
+    ttlMs = DEFAULT_RESERVATION_TTL_MS,
+  ): Promise<ReserveNonceResult> {
+    if (!Number.isInteger(ttlMs) || ttlMs < 1000) {
+      throw new BadRequestException(
+        'ttlMs must be an integer greater than or equal to 1000',
+      );
+    }
+
+    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedNetwork = this.normalizeNetwork(network);
+
+    return this.withLock(normalizedNetwork, normalizedAddress, async () => {
+      const state = await this.getOrInitState(normalizedAddress, normalizedNetwork);
+      await this.pruneExpiredReservations(state);
+
+      const nonce = this.findFirstAvailableNonce(state);
+      const reservationId = randomUUID();
+      const now = Date.now();
+      const expiresAt = new Date(now + ttlMs).toISOString();
+
+      state.reservations[String(nonce)] = {
+        reservationId,
+        nonce,
+        reservedAt: new Date(now).toISOString(),
+        expiresAt,
+      };
+      state.nextNonce = Math.max(state.nextNonce, nonce + 1);
+      state.updatedAt = new Date().toISOString();
+
+      await this.persistState(state);
+
+      return {
+        network: normalizedNetwork,
+        address: normalizedAddress,
+        nonce,
+        reservationId,
+        expiresAt,
+        chainNonce: state.chainNonce,
+        nextNonce: state.nextNonce,
+      };
+    });
+  }
+
+  async commitReservation(
+    address: string,
+    reservationId: string,
+    network = DEFAULT_NETWORK,
+  ): Promise<NonceState> {
+    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedNetwork = this.normalizeNetwork(network);
+
+    return this.withLock(normalizedNetwork, normalizedAddress, async () => {
+      const state = await this.getOrInitState(normalizedAddress, normalizedNetwork);
+      await this.pruneExpiredReservations(state);
+
+      const reservation = this.findReservationById(state, reservationId);
+      if (!reservation) {
+        throw new NotFoundException('Nonce reservation not found');
+      }
+
+      delete state.reservations[String(reservation.nonce)];
+      if (!state.usedNonces.includes(reservation.nonce)) {
+        state.usedNonces.push(reservation.nonce);
+      }
+      state.nextNonce = Math.max(state.nextNonce, reservation.nonce + 1);
+      state.usedNonces.sort((a, b) => a - b);
+      state.updatedAt = new Date().toISOString();
+
+      await this.persistState(state);
+      return state;
+    });
+  }
+
+  async releaseReservation(
+    address: string,
+    reservationId: string,
+    network = DEFAULT_NETWORK,
+  ): Promise<NonceState> {
+    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedNetwork = this.normalizeNetwork(network);
+
+    return this.withLock(normalizedNetwork, normalizedAddress, async () => {
+      const state = await this.getOrInitState(normalizedAddress, normalizedNetwork);
+      await this.pruneExpiredReservations(state);
+
+      const reservation = this.findReservationById(state, reservationId);
+      if (!reservation) {
+        throw new NotFoundException('Nonce reservation not found');
+      }
+
+      delete state.reservations[String(reservation.nonce)];
+      state.updatedAt = new Date().toISOString();
+
+      await this.persistState(state);
+      return state;
+    });
+  }
+
+  async syncNonce(address: string, network = DEFAULT_NETWORK): Promise<NonceState> {
+    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedNetwork = this.normalizeNetwork(network);
+
+    return this.withLock(normalizedNetwork, normalizedAddress, async () => {
+      const state = await this.getOrInitState(normalizedAddress, normalizedNetwork);
+      await this.pruneExpiredReservations(state);
+
+      const provider = this.getProvider(normalizedNetwork);
+      const chainNonce = await provider.getTransactionCount(
+        normalizedAddress,
+        'pending',
+      );
+
+      state.chainNonce = chainNonce;
+      if (state.nextNonce < chainNonce) {
+        state.nextNonce = chainNonce;
+      }
+      state.usedNonces = state.usedNonces.filter((nonce) => nonce >= chainNonce);
+      state.updatedAt = new Date().toISOString();
+
+      await this.persistState(state);
+      return state;
+    });
+  }
+
+  async fillNonceGaps(
+    address: string,
+    network = DEFAULT_NETWORK,
+    reserveFirstGap = false,
+    ttlMs = DEFAULT_RESERVATION_TTL_MS,
+  ): Promise<GapFillResult> {
+    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedNetwork = this.normalizeNetwork(network);
+
+    return this.withLock(normalizedNetwork, normalizedAddress, async () => {
+      const state = await this.getOrInitState(normalizedAddress, normalizedNetwork);
+      await this.pruneExpiredReservations(state);
+
+      const gapsBeforeReservation = this.detectGaps(state);
+      let reserved: ReserveNonceResult | undefined;
+
+      if (reserveFirstGap && gapsBeforeReservation.length > 0) {
+        if (!Number.isInteger(ttlMs) || ttlMs < 1000) {
+          throw new BadRequestException(
+            'ttlMs must be an integer greater than or equal to 1000',
+          );
+        }
+
+        const nonce = gapsBeforeReservation[0];
+        const hasConflict =
+          !!state.reservations[String(nonce)] || state.usedNonces.includes(nonce);
+        if (hasConflict) {
+          throw new ConflictException(
+            'Unable to reserve nonce gap due to conflict',
+          );
+        }
+
+        const reservationId = randomUUID();
+        const now = Date.now();
+        const expiresAt = new Date(now + ttlMs).toISOString();
+
+        state.reservations[String(nonce)] = {
+          reservationId,
+          nonce,
+          reservedAt: new Date(now).toISOString(),
+          expiresAt,
+        };
+        state.updatedAt = new Date().toISOString();
+
+        reserved = {
+          network: normalizedNetwork,
+          address: normalizedAddress,
+          nonce,
+          reservationId,
+          expiresAt,
+          chainNonce: state.chainNonce,
+          nextNonce: state.nextNonce,
+        };
+      }
+
+      await this.persistState(state);
+
+      return {
+        network: normalizedNetwork,
+        address: normalizedAddress,
+        chainNonce: state.chainNonce,
+        nextNonce: state.nextNonce,
+        gaps: this.detectGaps(state),
+        reserved,
+      };
+    });
+  }
+
+  private normalizeAddress(address: string): string {
+    try {
+      return ethers.getAddress(address);
+    } catch {
+      throw new BadRequestException('Invalid wallet address');
+    }
+  }
+
+  private normalizeNetwork(network: string): string {
+    return (network || DEFAULT_NETWORK).trim().toLowerCase();
+  }
+
+  private cacheKey(network: string, address: string): string {
+    return `nonce:state:${network}:${address}`;
+  }
+
+  private async getOrInitState(address: string, network: string): Promise<NonceState> {
+    const key = this.cacheKey(network, address);
+    const cached = await this.cache.get<NonceState>(key);
+    if (cached) {
+      return {
+        ...cached,
+        usedNonces: [...(cached.usedNonces ?? [])],
+        reservations: { ...(cached.reservations ?? {}) },
+      };
+    }
+
+    const provider = this.getProvider(network);
+    const chainNonce = await provider.getTransactionCount(address, 'pending');
+
+    const initialized: NonceState = {
+      network,
+      address,
+      chainNonce,
+      nextNonce: chainNonce,
+      usedNonces: [],
+      reservations: {},
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.persistState(initialized);
+    return initialized;
+  }
+
+  private async persistState(state: NonceState): Promise<void> {
+    await this.cache.set(this.cacheKey(state.network, state.address), state);
+  }
+
+  private async pruneExpiredReservations(state: NonceState): Promise<void> {
+    const now = Date.now();
+    for (const [nonceKey, reservation] of Object.entries(state.reservations)) {
+      const expiresAt = new Date(reservation.expiresAt).getTime();
+      if (Number.isNaN(expiresAt) || expiresAt <= now) {
+        delete state.reservations[nonceKey];
+      }
+    }
+  }
+
+  private findFirstAvailableNonce(state: NonceState): number {
+    const used = new Set(state.usedNonces);
+    const reserved = new Set(
+      Object.values(state.reservations).map((reservation) => reservation.nonce),
+    );
+
+    let candidate = Math.max(state.chainNonce, state.nextNonce);
+
+    while (used.has(candidate) || reserved.has(candidate)) {
+      candidate += 1;
+    }
+
+    return candidate;
+  }
+
+  private findReservationById(
+    state: NonceState,
+    reservationId: string,
+  ): NonceReservation | undefined {
+    return Object.values(state.reservations).find(
+      (reservation) => reservation.reservationId === reservationId,
+    );
+  }
+
+  private detectGaps(state: NonceState): number[] {
+    const used = new Set(state.usedNonces);
+    const reserved = new Set(
+      Object.values(state.reservations).map((reservation) => reservation.nonce),
+    );
+
+    const maxUsed = state.usedNonces.length > 0 ? Math.max(...state.usedNonces) : -1;
+    const maxReserved =
+      reserved.size > 0 ? Math.max(...Array.from(reserved.values())) : -1;
+    const highestKnown = Math.max(state.nextNonce, maxUsed + 1, maxReserved + 1);
+
+    const gaps: number[] = [];
+    for (let nonce = state.chainNonce; nonce < highestKnown; nonce += 1) {
+      if (!used.has(nonce) && !reserved.has(nonce)) {
+        gaps.push(nonce);
+      }
+    }
+
+    return gaps;
+  }
+
+  private getProvider(network: string): ethers.JsonRpcProvider {
+    const normalizedNetwork = this.normalizeNetwork(network);
+    const cached = this.providerCache.get(normalizedNetwork);
+    if (cached) return cached;
+
+    const networkConfigKey =
+      `BLOCKCHAIN_RPC_URL_${normalizedNetwork.toUpperCase()}`;
+    const fallbackRpc = this.config.get<string>(
+      'BLOCKCHAIN_RPC_URL',
+      'https://rpc.mantle.xyz',
+    );
+    const rpcUrl = this.config.get<string>(networkConfigKey, fallbackRpc);
+
+    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    this.providerCache.set(normalizedNetwork, provider);
+    return provider;
+  }
+
+  private async withLock<T>(
+    network: string,
+    address: string,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    const lockKey = `${network}:${address}`;
+    const previous = this.mutexes.get(lockKey) ?? Promise.resolve();
+
+    let release: () => void = () => undefined;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const lockToken = previous.then(() => current);
+    this.mutexes.set(lockKey, lockToken);
+
+    await previous;
+
+    try {
+      return await task();
+    } finally {
+      release();
+      if (this.mutexes.get(lockKey) === lockToken) {
+        this.mutexes.delete(lockKey);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #167

## Summary
- Added a backend nonce manager service that tracks nonce state per address and network using cache-backed persistence.
- Implemented nonce reservation, commit, release, chain sync, and gap-filling workflows to prevent nonce reuse/conflicts and recover missing nonces.
- Exposed authenticated blockchain nonce endpoints for reserve/commit/release/sync/fill-gaps and nonce state retrieval.
- Added focused unit tests for sequential reservation, conflict prevention, synchronization, and gap fill behavior.

## Validation
- `npm --prefix Backend run build`
- `npm --prefix Backend test`