### PR TITLE
feat: implement multi-level caching layer for market data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ Thumbs.db
 # Compiler files
 cache/
 out/
+!Backend/src/cache/
 
 # Ignores development broadcast logs
 !/broadcast

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -34,6 +34,7 @@ import { CategoriesModule } from './categories/categories.module';
 import { TradingPairModule } from './trading-pairs/trading-pair.module';
 import { WithdrawalModule } from './withdrawal/withdrawal.module';
 import { ApiKeysModule } from './api-keys/api-keys.module';
+import { AppCacheModule } from './cache/cache.module';
 
 @Module({
   imports: [
@@ -89,6 +90,7 @@ import { ApiKeysModule } from './api-keys/api-keys.module';
     TradingPairModule,
     WithdrawalModule,
     ApiKeysModule,
+    AppCacheModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/Backend/src/cache/cache.controller.ts
+++ b/Backend/src/cache/cache.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Delete, Param, UseGuards } from '@nestjs/common';
+import { CacheService } from './cache.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('cache')
+@UseGuards(JwtAuthGuard)
+export class CacheController {
+  constructor(private readonly cacheService: CacheService) {}
+
+  @Get('metrics')
+  getMetrics() {
+    return this.cacheService.getMetrics();
+  }
+
+  @Delete('key/:key')
+  async invalidateKey(@Param('key') key: string) {
+    await this.cacheService.del(key);
+    return { invalidated: key };
+  }
+
+  @Delete('pattern/:pattern')
+  async invalidatePattern(@Param('pattern') pattern: string) {
+    await this.cacheService.invalidatePattern(pattern);
+    return { invalidated: pattern };
+  }
+}

--- a/Backend/src/cache/cache.middleware.ts
+++ b/Backend/src/cache/cache.middleware.ts
@@ -1,0 +1,43 @@
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { CacheService } from './cache.service';
+
+const CACHEABLE_PATHS = ['/api/market-data'];
+const DEFAULT_TTL = 30_000; // 30s
+
+@Injectable()
+export class CacheMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(CacheMiddleware.name);
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    const isCacheable =
+      req.method === 'GET' &&
+      CACHEABLE_PATHS.some((p) => req.path.startsWith(p));
+
+    if (!isCacheable) return next();
+
+    const key = `http:${req.path}:${JSON.stringify(req.query)}`;
+    const cached = await this.cacheService.get(key);
+
+    if (cached) {
+      res.setHeader('X-Cache', 'HIT');
+      return res.json(cached);
+    }
+
+    // Intercept response to cache it
+    const originalJson = res.json.bind(res);
+    res.json = (body: unknown) => {
+      if (res.statusCode === 200) {
+        this.cacheService.set(key, body, DEFAULT_TTL).catch((err) =>
+          this.logger.warn(`Failed to cache response: ${err}`),
+        );
+      }
+      res.setHeader('X-Cache', 'MISS');
+      return originalJson(body);
+    };
+
+    next();
+  }
+}

--- a/Backend/src/cache/cache.module.ts
+++ b/Backend/src/cache/cache.module.ts
@@ -1,0 +1,17 @@
+import { Module, MiddlewareConsumer, RequestMethod } from '@nestjs/common';
+import { CacheService } from './cache.service';
+import { CacheController } from './cache.controller';
+import { CacheMiddleware } from './cache.middleware';
+
+@Module({
+  providers: [CacheService],
+  controllers: [CacheController],
+  exports: [CacheService],
+})
+export class AppCacheModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(CacheMiddleware)
+      .forRoutes({ path: 'market-data*', method: RequestMethod.GET });
+  }
+}

--- a/Backend/src/cache/cache.service.ts
+++ b/Backend/src/cache/cache.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
+
+interface L1Entry {
+  value: unknown;
+  expiresAt: number;
+}
+
+interface CacheMetrics {
+  hits: number;
+  misses: number;
+  l1Hits: number;
+  l2Hits: number;
+  sets: number;
+  invalidations: number;
+}
+
+@Injectable()
+export class CacheService {
+  private readonly logger = new Logger(CacheService.name);
+  private readonly l1: Map<string, L1Entry> = new Map();
+  private readonly l1MaxSize = 500;
+  private readonly l1DefaultTtl = 30_000; // 30s in ms
+
+  private readonly metrics: CacheMetrics = {
+    hits: 0,
+    misses: 0,
+    l1Hits: 0,
+    l2Hits: 0,
+    sets: 0,
+    invalidations: 0,
+  };
+
+  constructor(@Inject(CACHE_MANAGER) private readonly redis: Cache) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    // L1 check
+    const l1Entry = this.l1.get(key);
+    if (l1Entry) {
+      if (Date.now() < l1Entry.expiresAt) {
+        this.metrics.hits++;
+        this.metrics.l1Hits++;
+        return l1Entry.value as T;
+      }
+      this.l1.delete(key);
+    }
+
+    // L2 (Redis) check
+    const value = await this.redis.get<T>(key);
+    if (value !== null && value !== undefined) {
+      this.metrics.hits++;
+      this.metrics.l2Hits++;
+      this.setL1(key, value, this.l1DefaultTtl);
+      return value;
+    }
+
+    this.metrics.misses++;
+    return null;
+  }
+
+  async set(key: string, value: unknown, ttlMs: number): Promise<void> {
+    this.metrics.sets++;
+    this.setL1(key, value, Math.min(ttlMs, this.l1DefaultTtl));
+    await this.redis.set(key, value, ttlMs);
+  }
+
+  async del(key: string): Promise<void> {
+    this.metrics.invalidations++;
+    this.l1.delete(key);
+    await this.redis.del(key);
+  }
+
+  async invalidatePattern(pattern: string): Promise<void> {
+    // Invalidate L1 keys matching prefix pattern
+    for (const key of this.l1.keys()) {
+      if (key.startsWith(pattern)) {
+        this.l1.delete(key);
+        this.metrics.invalidations++;
+      }
+    }
+    // Redis key-scan based invalidation
+    try {
+      const store = (this.redis as any).store;
+      const client = store?.client ?? store?.getClient?.();
+      if (client?.scan) {
+        let cursor = '0';
+        do {
+          const [nextCursor, keys] = await client.scan(
+            cursor,
+            'MATCH',
+            `*${pattern}*`,
+            'COUNT',
+            100,
+          );
+          cursor = nextCursor;
+          if (keys.length) {
+            await client.del(...keys);
+            this.metrics.invalidations += keys.length;
+          }
+        } while (cursor !== '0');
+      }
+    } catch (err) {
+      this.logger.warn(`Pattern invalidation failed for "${pattern}": ${err}`);
+    }
+  }
+
+  async getOrSet<T>(
+    key: string,
+    factory: () => Promise<T>,
+    ttlMs: number,
+  ): Promise<T> {
+    const cached = await this.get<T>(key);
+    if (cached !== null) return cached;
+
+    const value = await factory();
+    await this.set(key, value, ttlMs);
+    return value;
+  }
+
+  async warm(entries: Array<{ key: string; factory: () => Promise<unknown>; ttlMs: number }>) {
+    this.logger.log(`Warming ${entries.length} cache entries...`);
+    await Promise.allSettled(
+      entries.map(({ key, factory, ttlMs }) =>
+        factory()
+          .then((v) => this.set(key, v, ttlMs))
+          .catch((err) => this.logger.warn(`Warm failed for ${key}: ${err}`)),
+      ),
+    );
+    this.logger.log('Cache warming complete');
+  }
+
+  getMetrics() {
+    const total = this.metrics.hits + this.metrics.misses;
+    return {
+      ...this.metrics,
+      hitRate: total > 0 ? ((this.metrics.hits / total) * 100).toFixed(2) + '%' : '0%',
+      l1Size: this.l1.size,
+    };
+  }
+
+  private setL1(key: string, value: unknown, ttlMs: number) {
+    if (this.l1.size >= this.l1MaxSize) {
+      // Evict oldest entry
+      const firstKey = this.l1.keys().next().value;
+      if (firstKey) this.l1.delete(firstKey);
+    }
+    this.l1.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+}

--- a/Backend/src/market-data/market-data.module.ts
+++ b/Backend/src/market-data/market-data.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { MarketDataService } from './market-data.service';
 import { MarketDataController } from './market-data.controller';
+import { AppCacheModule } from '../cache/cache.module';
 
 @Module({
-  imports: [HttpModule],
+  imports: [HttpModule, AppCacheModule],
   controllers: [MarketDataController],
   providers: [MarketDataService],
   exports: [MarketDataService],

--- a/Backend/src/market-data/market-data.service.ts
+++ b/Backend/src/market-data/market-data.service.ts
@@ -1,13 +1,11 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import type { Cache } from 'cache-manager';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { firstValueFrom } from 'rxjs';
+import { CacheService } from '../cache/cache.service';
 
-const CACHE_TTL = 300; // 5 minutes
-const FLIGHTS_CACHE_KEY = 'flights:all';
+const TTL = 5 * 60 * 1000; // 5 minutes
 
 @Injectable()
 export class MarketDataService {
@@ -18,7 +16,7 @@ export class MarketDataService {
   constructor(
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
-    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly cache: CacheService,
   ) {
     this.apiKey = this.configService.get<string>('AVIATION_STACK_API_KEY', '');
   }
@@ -30,81 +28,57 @@ export class MarketDataService {
     limit?: number;
     offset?: number;
   }) {
-    const cacheKey = `flights:${JSON.stringify(params)}`;
-    const cached = await this.cacheManager.get(cacheKey);
-    if (cached) return cached;
-
-    const data = await this.fetchFromAviationStack('/flights', {
-      flight_status: params.flightStatus,
-      airline_name: params.airline,
-      flight_iata: params.flightNumber,
-      limit: params.limit ?? 20,
-      offset: params.offset ?? 0,
-    });
-
-    await this.cacheManager.set(cacheKey, data, CACHE_TTL * 1000);
-    return data;
+    const key = `flights:${JSON.stringify(params)}`;
+    return this.cache.getOrSet(key, () =>
+      this.fetch('/flights', {
+        flight_status: params.flightStatus,
+        airline_name: params.airline,
+        flight_iata: params.flightNumber,
+        limit: params.limit ?? 20,
+        offset: params.offset ?? 0,
+      }), TTL);
   }
 
   async getFlightByIata(iata: string) {
-    const cacheKey = `flight:${iata}`;
-    const cached = await this.cacheManager.get(cacheKey);
-    if (cached) return cached;
-
-    const data = await this.fetchFromAviationStack('/flights', {
-      flight_iata: iata,
-      limit: 1,
-    });
-
-    await this.cacheManager.set(cacheKey, data, CACHE_TTL * 1000);
-    return data;
+    return this.cache.getOrSet(`flight:${iata}`, () =>
+      this.fetch('/flights', { flight_iata: iata, limit: 1 }), TTL);
   }
 
   async getAirlines(params: { search?: string; limit?: number }) {
-    const cacheKey = `airlines:${JSON.stringify(params)}`;
-    const cached = await this.cacheManager.get(cacheKey);
-    if (cached) return cached;
-
-    const data = await this.fetchFromAviationStack('/airlines', {
-      search: params.search,
-      limit: params.limit ?? 20,
-    });
-
-    await this.cacheManager.set(cacheKey, data, CACHE_TTL * 1000);
-    return data;
+    const key = `airlines:${JSON.stringify(params)}`;
+    return this.cache.getOrSet(key, () =>
+      this.fetch('/airlines', { search: params.search, limit: params.limit ?? 20 }), TTL);
   }
 
   @Cron(CronExpression.EVERY_5_MINUTES)
-  async refreshFlightData() {
-    this.logger.log('Refreshing flight data cache...');
-    try {
-      const data = await this.fetchFromAviationStack('/flights', {
-        flight_status: 'active',
-        limit: 100,
-      });
-      await this.cacheManager.set(FLIGHTS_CACHE_KEY, data, CACHE_TTL * 1000);
-      this.logger.log('Flight data cache refreshed');
-    } catch (err) {
-      this.logger.error('Failed to refresh flight data', err);
-    }
+  async warmPopularData() {
+    this.logger.log('Warming popular market data cache...');
+    await this.cache.warm([
+      {
+        key: 'flights:active',
+        factory: () => this.fetch('/flights', { flight_status: 'active', limit: 100 }),
+        ttlMs: TTL,
+      },
+      {
+        key: 'airlines:top',
+        factory: () => this.fetch('/airlines', { limit: 50 }),
+        ttlMs: TTL,
+      },
+    ]);
   }
 
-  private async fetchFromAviationStack(
-    endpoint: string,
-    params: Record<string, unknown>,
-  ) {
-    const cleanParams = Object.fromEntries(
+  private async fetch(endpoint: string, params: Record<string, unknown>) {
+    const clean = Object.fromEntries(
       Object.entries({ ...params, access_key: this.apiKey }).filter(
         ([, v]) => v !== undefined && v !== null && v !== '',
       ),
     );
-
-    const response = await firstValueFrom(
+    const res = await firstValueFrom(
       this.httpService.get(`${this.baseUrl}${endpoint}`, {
-        params: cleanParams,
+        params: clean,
         timeout: 10000,
       }),
     );
-    return response.data;
+    return res.data;
   }
 }


### PR DESCRIPTION
- Add CacheService with L1 in-memory (Map, 500 entries, 30s TTL) + L2 Redis
- Add CacheMiddleware for HTTP-level caching on market-data routes with X-Cache headers
- Add CacheController with metrics, key invalidation, and pattern invalidation endpoints
- Refactor MarketDataService to use CacheService with getOrSet pattern
- Add cache warming via cron job for popular flights and airlines data
- Fix .gitignore to allow Backend/src/cache/ (was caught by Foundry cache/ rule)

Closes: multi-level cache layer feature

closes #109 
