### PR TITLE
feat: push notification service with multi-channel support

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -31,3 +31,6 @@ GROQ_API_KEY=your_groq_api_key_here
 
 # Gas estimation (optional — Etherscan enrichment for mainnet)
 ETHERSCAN_API_KEY=your_etherscan_api_key_here
+
+# Firebase (push notifications — paste the service account JSON as a single line)
+FIREBASE_SERVICE_ACCOUNT=

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -34,6 +34,8 @@ import { CategoriesModule } from './categories/categories.module';
 import { TradingPairModule } from './trading-pairs/trading-pair.module';
 import { WithdrawalModule } from './withdrawal/withdrawal.module';
 import { ApiKeysModule } from './api-keys/api-keys.module';
+import { AppCacheModule } from './cache/cache.module';
+import { NotificationModule } from './notifications/notification.module';
 
 @Module({
   imports: [
@@ -89,6 +91,8 @@ import { ApiKeysModule } from './api-keys/api-keys.module';
     TradingPairModule,
     WithdrawalModule,
     ApiKeysModule,
+    AppCacheModule,
+    NotificationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/Backend/src/notifications/dto/notification.dto.ts
+++ b/Backend/src/notifications/dto/notification.dto.ts
@@ -1,0 +1,48 @@
+import { IsString, IsEnum, IsOptional, IsObject, IsBoolean, IsArray } from 'class-validator';
+import { NotificationChannel, NotificationType } from '../notification.entity';
+
+export class SendNotificationDto {
+  @IsString()
+  userId: string;
+
+  @IsEnum(['trade_confirmation', 'market_update', 'price_alert', 'system', 'weekly_digest'])
+  type: NotificationType;
+
+  @IsEnum(['email', 'push', 'in-app'])
+  @IsOptional()
+  channel?: NotificationChannel;
+
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  body?: string;
+
+  @IsObject()
+  @IsOptional()
+  data?: Record<string, unknown>;
+}
+
+export class UpdatePreferencesDto {
+  @IsBoolean()
+  @IsOptional()
+  email?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  push?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  inApp?: boolean;
+
+  @IsArray()
+  @IsOptional()
+  optedOutTypes?: NotificationType[];
+
+  @IsString()
+  @IsOptional()
+  fcmToken?: string;
+}

--- a/Backend/src/notifications/notification.controller.ts
+++ b/Backend/src/notifications/notification.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { NotificationService } from './notification.service';
+import { SendNotificationDto, UpdatePreferencesDto } from './dto/notification.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+export class NotificationController {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  @Post('send')
+  send(@Body() dto: SendNotificationDto) {
+    return this.notificationService.send(dto);
+  }
+
+  @Get()
+  getMyNotifications(@Request() req: any) {
+    return this.notificationService.getForUser(req.user.id);
+  }
+
+  @Patch(':id/read')
+  markRead(@Request() req: any, @Param('id') id: string) {
+    return this.notificationService.markRead(req.user.id, id);
+  }
+
+  @Get('preferences')
+  getPreferences(@Request() req: any) {
+    return this.notificationService.getPrefs(req.user.id);
+  }
+
+  @Patch('preferences')
+  updatePreferences(@Request() req: any, @Body() dto: UpdatePreferencesDto) {
+    return this.notificationService.updatePrefs(req.user.id, dto);
+  }
+
+  @Get('metrics')
+  getMetrics(@Request() req: any) {
+    return this.notificationService.getMetrics(req.user.id);
+  }
+}

--- a/Backend/src/notifications/notification.entity.ts
+++ b/Backend/src/notifications/notification.entity.ts
@@ -1,0 +1,33 @@
+export type NotificationChannel = 'email' | 'push' | 'in-app';
+export type NotificationStatus = 'queued' | 'sent' | 'failed' | 'read';
+export type NotificationType =
+  | 'trade_confirmation'
+  | 'market_update'
+  | 'price_alert'
+  | 'system'
+  | 'weekly_digest';
+
+export interface Notification {
+  id: string;
+  userId: string;
+  type: NotificationType;
+  channel: NotificationChannel;
+  title: string;
+  body: string;
+  data?: Record<string, unknown>;
+  status: NotificationStatus;
+  attempts: number;
+  createdAt: Date;
+  sentAt?: Date;
+  readAt?: Date;
+  error?: string;
+}
+
+export interface NotificationPreferences {
+  userId: string;
+  email: boolean;
+  push: boolean;
+  inApp: boolean;
+  optedOutTypes: NotificationType[];
+  fcmToken?: string;
+}

--- a/Backend/src/notifications/notification.module.ts
+++ b/Backend/src/notifications/notification.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+import { NotificationController } from './notification.controller';
+
+@Module({
+  controllers: [NotificationController],
+  providers: [NotificationService],
+  exports: [NotificationService],
+})
+export class NotificationModule {}

--- a/Backend/src/notifications/notification.service.ts
+++ b/Backend/src/notifications/notification.service.ts
@@ -1,0 +1,229 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  Notification,
+  NotificationChannel,
+  NotificationPreferences,
+} from './notification.entity';
+import { SendNotificationDto, UpdatePreferencesDto } from './dto/notification.dto';
+import { renderTemplate } from './notification.templates';
+
+@Injectable()
+export class NotificationService {
+  private readonly logger = new Logger(NotificationService.name);
+
+  // In-memory stores (swap for DB in production)
+  private readonly notifications = new Map<string, Notification>();
+  private readonly preferences = new Map<string, NotificationPreferences>();
+
+  // Simple in-process queue — swap for Bull/Redis queue in production
+  private readonly queue: Notification[] = [];
+  private processing = false;
+
+  constructor(private readonly config: ConfigService) {
+    // Drain queue every 2 seconds
+    setInterval(() => this.drainQueue(), 2000);
+  }
+
+  // ─── Public API ────────────────────────────────────────────────────────────
+
+  async send(dto: SendNotificationDto): Promise<Notification[]> {
+    const prefs = this.getPrefs(dto.userId);
+    const { title, body } = renderTemplate(dto.type, dto.data);
+
+    if (prefs.optedOutTypes.includes(dto.type)) {
+      this.logger.debug(`User ${dto.userId} opted out of ${dto.type}`);
+      return [];
+    }
+
+    const channels = dto.channel
+      ? [dto.channel]
+      : this.resolveChannels(prefs);
+
+    const created: Notification[] = channels.map((channel) => {
+      const n: Notification = {
+        id: uuidv4(),
+        userId: dto.userId,
+        type: dto.type,
+        channel,
+        title: dto.title ?? title,
+        body: dto.body ?? body,
+        data: dto.data,
+        status: 'queued',
+        attempts: 0,
+        createdAt: new Date(),
+      };
+      this.notifications.set(n.id, n);
+      this.queue.push(n);
+      return n;
+    });
+
+    this.logger.log(`Queued ${created.length} notification(s) for user ${dto.userId}`);
+    return created;
+  }
+
+  getForUser(userId: string): Notification[] {
+    return [...this.notifications.values()]
+      .filter((n) => n.userId === userId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  }
+
+  markRead(userId: string, notificationId: string): Notification {
+    const n = this.notifications.get(notificationId);
+    if (!n || n.userId !== userId) throw new NotFoundException('Notification not found');
+    n.status = 'read';
+    n.readAt = new Date();
+    return n;
+  }
+
+  getPrefs(userId: string): NotificationPreferences {
+    if (!this.preferences.has(userId)) {
+      this.preferences.set(userId, {
+        userId,
+        email: true,
+        push: true,
+        inApp: true,
+        optedOutTypes: [],
+      });
+    }
+    return this.preferences.get(userId)!;
+  }
+
+  updatePrefs(userId: string, dto: UpdatePreferencesDto): NotificationPreferences {
+    const prefs = this.getPrefs(userId);
+    if (dto.email !== undefined) prefs.email = dto.email;
+    if (dto.push !== undefined) prefs.push = dto.push;
+    if (dto.inApp !== undefined) prefs.inApp = dto.inApp;
+    if (dto.optedOutTypes !== undefined) prefs.optedOutTypes = dto.optedOutTypes;
+    if (dto.fcmToken !== undefined) prefs.fcmToken = dto.fcmToken;
+    return prefs;
+  }
+
+  getMetrics(userId?: string) {
+    const all = userId
+      ? [...this.notifications.values()].filter((n) => n.userId === userId)
+      : [...this.notifications.values()];
+
+    return {
+      total: all.length,
+      queued: all.filter((n) => n.status === 'queued').length,
+      sent: all.filter((n) => n.status === 'sent').length,
+      failed: all.filter((n) => n.status === 'failed').length,
+      read: all.filter((n) => n.status === 'read').length,
+      byChannel: {
+        email: all.filter((n) => n.channel === 'email').length,
+        push: all.filter((n) => n.channel === 'push').length,
+        'in-app': all.filter((n) => n.channel === 'in-app').length,
+      },
+    };
+  }
+
+  // ─── Queue Processing ───────────────────────────────────────────────────────
+
+  private async drainQueue() {
+    if (this.processing || this.queue.length === 0) return;
+    this.processing = true;
+
+    const batch = this.queue.splice(0, 10);
+    await Promise.allSettled(batch.map((n) => this.dispatch(n)));
+
+    this.processing = false;
+  }
+
+  private async dispatch(n: Notification) {
+    n.attempts++;
+    try {
+      if (n.channel === 'email') await this.sendEmail(n);
+      else if (n.channel === 'push') await this.sendPush(n);
+      // in-app: already stored in memory, no external dispatch needed
+      n.status = 'sent';
+      n.sentAt = new Date();
+    } catch (err: any) {
+      this.logger.warn(`Failed to dispatch ${n.id} via ${n.channel}: ${err.message}`);
+      n.error = err.message;
+      // Retry up to 3 times
+      if (n.attempts < 3) {
+        n.status = 'queued';
+        this.queue.push(n);
+      } else {
+        n.status = 'failed';
+      }
+    }
+  }
+
+  // ─── Channel Dispatchers ────────────────────────────────────────────────────
+
+  private async sendEmail(n: Notification) {
+    const transporter = nodemailer.createTransport({
+      host: this.config.get('SMTP_HOST'),
+      port: this.config.get<number>('SMTP_PORT', 587),
+      auth: {
+        user: this.config.get('SMTP_USER'),
+        pass: this.config.get('SMTP_PASS'),
+      },
+    });
+
+    const { emailHtml } = renderTemplate(n.type, n.data);
+
+    await transporter.sendMail({
+      from: this.config.get('EMAIL_FROM', 'noreply@gatedelay.com'),
+      to: n.data?.email as string | undefined,
+      subject: n.title,
+      html: emailHtml,
+    });
+  }
+
+  private async sendPush(n: Notification) {
+    // FCM via firebase-admin — initialise lazily so missing config doesn't crash the app
+    const admin = await this.getFirebaseAdmin();
+    if (!admin) {
+      this.logger.warn('Firebase Admin not configured — skipping push');
+      return;
+    }
+
+    const prefs = this.preferences.get(n.userId);
+    if (!prefs?.fcmToken) {
+      this.logger.debug(`No FCM token for user ${n.userId}`);
+      return;
+    }
+
+    await admin.messaging().send({
+      token: prefs.fcmToken,
+      notification: { title: n.title, body: n.body },
+      data: n.data ? Object.fromEntries(
+        Object.entries(n.data).map(([k, v]) => [k, String(v)])
+      ) : undefined,
+    });
+  }
+
+  private firebaseAdmin: any = null;
+  private async getFirebaseAdmin() {
+    if (this.firebaseAdmin) return this.firebaseAdmin;
+    const serviceAccountJson = this.config.get<string>('FIREBASE_SERVICE_ACCOUNT');
+    if (!serviceAccountJson) return null;
+    try {
+      const admin = await import('firebase-admin');
+      if (!admin.apps.length) {
+        admin.initializeApp({
+          credential: admin.credential.cert(JSON.parse(serviceAccountJson)),
+        });
+      }
+      this.firebaseAdmin = admin;
+      return admin;
+    } catch {
+      return null;
+    }
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────────────
+
+  private resolveChannels(prefs: NotificationPreferences): NotificationChannel[] {
+    const channels: NotificationChannel[] = [];
+    if (prefs.email) channels.push('email');
+    if (prefs.push) channels.push('push');
+    if (prefs.inApp) channels.push('in-app');
+    return channels.length ? channels : ['in-app'];
+  }
+}

--- a/Backend/src/notifications/notification.templates.ts
+++ b/Backend/src/notifications/notification.templates.ts
@@ -1,0 +1,51 @@
+import { NotificationType } from './notification.entity';
+
+interface Template {
+  title: (data?: Record<string, unknown>) => string;
+  body: (data?: Record<string, unknown>) => string;
+  emailHtml: (data?: Record<string, unknown>) => string;
+}
+
+export const TEMPLATES: Record<NotificationType, Template> = {
+  trade_confirmation: {
+    title: () => 'Trade Confirmed',
+    body: (d) => `Your trade on "${d?.market ?? 'market'}" was confirmed. Amount: ${d?.amount ?? '—'}`,
+    emailHtml: (d) =>
+      `<p>Your trade on <strong>${d?.market ?? 'market'}</strong> has been confirmed.</p><p>Amount: ${d?.amount ?? '—'}</p>`,
+  },
+  market_update: {
+    title: (d) => `Market Update: ${d?.market ?? ''}`,
+    body: (d) => `${d?.message ?? 'A market you follow has been updated.'}`,
+    emailHtml: (d) =>
+      `<p><strong>${d?.market ?? 'A market'}</strong> has been updated.</p><p>${d?.message ?? ''}</p>`,
+  },
+  price_alert: {
+    title: (d) => `Price Alert: ${d?.market ?? ''}`,
+    body: (d) => `Price moved to ${d?.price ?? '—'} (${d?.change ?? ''})`,
+    emailHtml: (d) =>
+      `<p>Price alert triggered for <strong>${d?.market ?? 'market'}</strong>.</p><p>Current price: ${d?.price ?? '—'} (${d?.change ?? ''})</p>`,
+  },
+  system: {
+    title: () => 'System Notification',
+    body: (d) => `${d?.message ?? 'A system event occurred.'}`,
+    emailHtml: (d) => `<p>${d?.message ?? 'A system event occurred.'}</p>`,
+  },
+  weekly_digest: {
+    title: () => 'Your Weekly GateDelay Digest',
+    body: (d) => `You had ${d?.trades ?? 0} trades this week. P&L: ${d?.pnl ?? '—'}`,
+    emailHtml: (d) =>
+      `<h2>Weekly Digest</h2><p>Trades: ${d?.trades ?? 0}</p><p>P&amp;L: ${d?.pnl ?? '—'}</p>`,
+  },
+};
+
+export function renderTemplate(
+  type: NotificationType,
+  data?: Record<string, unknown>,
+) {
+  const t = TEMPLATES[type];
+  return {
+    title: t.title(data),
+    body: t.body(data),
+    emailHtml: t.emailHtml(data),
+  };
+}


### PR DESCRIPTION
- Add NotificationService with in-process queue, 3-attempt retry logic
- Support email (nodemailer), push (Firebase FCM), and in-app channels
- Add notification templates for trade_confirmation, market_update, price_alert, system, weekly_digest
- Add user preference management with per-type opt-out support
- Add delivery metrics endpoint (total, sent, failed, read, by channel)
- Lazy-load Firebase Admin so missing config does not crash the app
- Wire NotificationModule into AppModule

closes #110 
