### PR TITLE
feat: KYC storage, market freeze, withdrawal queue & limit (#160-#163)

### DIFF
--- a/Contracts/contracts/KYCStorage.sol
+++ b/Contracts/contracts/KYCStorage.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title KYCStorage
+/// @notice Stores KYC verification data with role-gated writes and query helpers.
+contract KYCStorage is Ownable {
+    // -------------------------------------------------------------------------
+    // Custom errors
+    // -------------------------------------------------------------------------
+    error ZeroAddress();
+    error NotVerifier();
+    error AlreadyVerifier();
+    error UnknownRecord();
+    error InvalidStatus();
+    error InvalidLevel();
+
+    // -------------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------------
+    enum Status { NONE, PENDING, VERIFIED, REJECTED, EXPIRED, REVOKED }
+
+    struct Record {
+        Status status;
+        uint8 level;             // 0 = none, 1 = basic, 2 = enhanced, 3 = institutional
+        uint64 verifiedAt;
+        uint64 expiresAt;        // 0 = no expiry
+        uint64 updatedAt;
+        address verifier;
+        bytes32 documentHash;    // hash of off-chain documents
+        string jurisdiction;     // ISO country code
+    }
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+    event VerifierAdded(address indexed verifier);
+    event VerifierRemoved(address indexed verifier);
+    event RecordSubmitted(address indexed user, bytes32 documentHash, string jurisdiction);
+    event RecordUpdated(
+        address indexed user,
+        Status indexed status,
+        uint8 level,
+        address indexed verifier,
+        uint64 expiresAt
+    );
+    event RecordRevoked(address indexed user, address indexed verifier, string reason);
+
+    // -------------------------------------------------------------------------
+    // Storage
+    // -------------------------------------------------------------------------
+    mapping(address => Record) private _records;
+    mapping(address => bool) private _verifiers;
+    address[] private _verifierList;
+    address[] private _userList;
+    mapping(address => bool) private _userListed;
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+    constructor(address initialOwner) Ownable(initialOwner) {
+        // owner is implicitly able to add verifiers; they are not a verifier by default
+    }
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+    modifier onlyVerifier() {
+        if (!_verifiers[msg.sender]) revert NotVerifier();
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Verifier management
+    // -------------------------------------------------------------------------
+
+    /// @notice Add an account that may write KYC records.
+    function addVerifier(address verifier) external onlyOwner {
+        if (verifier == address(0)) revert ZeroAddress();
+        if (_verifiers[verifier]) revert AlreadyVerifier();
+        _verifiers[verifier] = true;
+        _verifierList.push(verifier);
+        emit VerifierAdded(verifier);
+    }
+
+    /// @notice Remove a verifier.
+    function removeVerifier(address verifier) external onlyOwner {
+        if (!_verifiers[verifier]) revert NotVerifier();
+        _verifiers[verifier] = false;
+
+        uint256 len = _verifierList.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (_verifierList[i] == verifier) {
+                _verifierList[i] = _verifierList[len - 1];
+                _verifierList.pop();
+                break;
+            }
+        }
+        emit VerifierRemoved(verifier);
+    }
+
+    /// @notice Whether the supplied account is registered as a verifier.
+    function isVerifier(address account) external view returns (bool) {
+        return _verifiers[account];
+    }
+
+    /// @notice Read all current verifier addresses.
+    function getVerifiers() external view returns (address[] memory) {
+        return _verifierList;
+    }
+
+    // -------------------------------------------------------------------------
+    // Record writes
+    // -------------------------------------------------------------------------
+
+    /// @notice User-facing entry point: submit a KYC record for review.
+    /// @dev Marks the record as PENDING; verifier later finalises status.
+    function submit(bytes32 documentHash, string calldata jurisdiction) external {
+        Record storage rec = _records[msg.sender];
+        rec.status = Status.PENDING;
+        rec.documentHash = documentHash;
+        rec.jurisdiction = jurisdiction;
+        rec.updatedAt = uint64(block.timestamp);
+
+        if (!_userListed[msg.sender]) {
+            _userListed[msg.sender] = true;
+            _userList.push(msg.sender);
+        }
+        emit RecordSubmitted(msg.sender, documentHash, jurisdiction);
+    }
+
+    /// @notice Verifier finalises a user's KYC outcome.
+    function setVerification(
+        address user,
+        Status status,
+        uint8 level,
+        uint64 expiresAt
+    ) external onlyVerifier {
+        if (user == address(0)) revert ZeroAddress();
+        if (status == Status.NONE) revert InvalidStatus();
+        if (level > 3) revert InvalidLevel();
+
+        Record storage rec = _records[user];
+        rec.status = status;
+        rec.level = level;
+        rec.verifier = msg.sender;
+        rec.updatedAt = uint64(block.timestamp);
+        rec.expiresAt = expiresAt;
+        if (status == Status.VERIFIED) {
+            rec.verifiedAt = uint64(block.timestamp);
+        }
+
+        if (!_userListed[user]) {
+            _userListed[user] = true;
+            _userList.push(user);
+        }
+        emit RecordUpdated(user, status, level, msg.sender, expiresAt);
+    }
+
+    /// @notice Revoke a previously verified record.
+    function revoke(address user, string calldata reason) external onlyVerifier {
+        Record storage rec = _records[user];
+        if (rec.status == Status.NONE) revert UnknownRecord();
+        rec.status = Status.REVOKED;
+        rec.updatedAt = uint64(block.timestamp);
+        rec.verifier = msg.sender;
+        emit RecordRevoked(user, msg.sender, reason);
+    }
+
+    // -------------------------------------------------------------------------
+    // Queries
+    // -------------------------------------------------------------------------
+
+    /// @notice Return the full KYC record for a user.
+    function getRecord(address user) external view returns (Record memory) {
+        return _records[user];
+    }
+
+    /// @notice Effective verification status, accounting for expiry.
+    function statusOf(address user) public view returns (Status) {
+        Record storage rec = _records[user];
+        if (rec.status == Status.VERIFIED && rec.expiresAt != 0 && block.timestamp >= rec.expiresAt) {
+            return Status.EXPIRED;
+        }
+        return rec.status;
+    }
+
+    /// @notice Convenience predicate: user is currently verified at >= minLevel.
+    function isVerified(address user, uint8 minLevel) external view returns (bool) {
+        Record storage rec = _records[user];
+        if (rec.status != Status.VERIFIED) return false;
+        if (rec.expiresAt != 0 && block.timestamp >= rec.expiresAt) return false;
+        return rec.level >= minLevel;
+    }
+
+    /// @notice Block timestamp at which the user's verification expires (0 = none).
+    function expiryOf(address user) external view returns (uint64) {
+        return _records[user].expiresAt;
+    }
+
+    /// @notice Number of users that have ever submitted or been written by a verifier.
+    function userCount() external view returns (uint256) {
+        return _userList.length;
+    }
+
+    /// @notice Paginated list of known users.
+    function listUsers(uint256 offset, uint256 limit) external view returns (address[] memory page) {
+        uint256 total = _userList.length;
+        if (offset >= total) return new address[](0);
+        uint256 end = offset + limit;
+        if (end > total) end = total;
+        page = new address[](end - offset);
+        for (uint256 i = offset; i < end; i++) {
+            page[i - offset] = _userList[i];
+        }
+    }
+}

--- a/Contracts/contracts/MarketFreeze.sol
+++ b/Contracts/contracts/MarketFreeze.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title MarketFreeze
+/// @notice Per-market and per-operation freeze controls for emergency response.
+contract MarketFreeze is Ownable {
+    // -------------------------------------------------------------------------
+    // Custom errors
+    // -------------------------------------------------------------------------
+    error ZeroAddress();
+    error NotFreezer();
+    error AlreadyFreezer();
+    error MarketAlreadyFrozen(bytes32 op);
+    error MarketNotFrozen(bytes32 op);
+    error OperationFrozen(bytes32 op);
+    error InvalidMarket();
+
+    // -------------------------------------------------------------------------
+    // Built-in operation identifiers
+    // -------------------------------------------------------------------------
+    bytes32 public constant OP_ALL      = keccak256("OP_ALL");
+    bytes32 public constant OP_TRADE    = keccak256("OP_TRADE");
+    bytes32 public constant OP_DEPOSIT  = keccak256("OP_DEPOSIT");
+    bytes32 public constant OP_WITHDRAW = keccak256("OP_WITHDRAW");
+    bytes32 public constant OP_RESOLVE  = keccak256("OP_RESOLVE");
+
+    // -------------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------------
+    struct FreezeInfo {
+        bool frozen;
+        address frozenBy;
+        uint64 frozenAt;
+        string reason;
+    }
+
+    // -------------------------------------------------------------------------
+    // Storage
+    // -------------------------------------------------------------------------
+    /// @dev market => operation => freeze info
+    mapping(address => mapping(bytes32 => FreezeInfo)) private _freezes;
+
+    /// @dev addresses authorised to freeze/unfreeze
+    mapping(address => bool) private _freezers;
+    address[] private _freezerList;
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+    event FreezerAdded(address indexed freezer);
+    event FreezerRemoved(address indexed freezer);
+    event MarketFrozen(address indexed market, bytes32 indexed operation, address indexed by, string reason);
+    event MarketUnfrozen(address indexed market, bytes32 indexed operation, address indexed by);
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+    modifier onlyFreezer() {
+        if (!_freezers[msg.sender] && msg.sender != owner()) revert NotFreezer();
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Freezer registry
+    // -------------------------------------------------------------------------
+    function addFreezer(address freezer) external onlyOwner {
+        if (freezer == address(0)) revert ZeroAddress();
+        if (_freezers[freezer]) revert AlreadyFreezer();
+        _freezers[freezer] = true;
+        _freezerList.push(freezer);
+        emit FreezerAdded(freezer);
+    }
+
+    function removeFreezer(address freezer) external onlyOwner {
+        if (!_freezers[freezer]) revert NotFreezer();
+        _freezers[freezer] = false;
+
+        uint256 len = _freezerList.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (_freezerList[i] == freezer) {
+                _freezerList[i] = _freezerList[len - 1];
+                _freezerList.pop();
+                break;
+            }
+        }
+        emit FreezerRemoved(freezer);
+    }
+
+    function isFreezer(address account) external view returns (bool) {
+        return _freezers[account];
+    }
+
+    function getFreezers() external view returns (address[] memory) {
+        return _freezerList;
+    }
+
+    // -------------------------------------------------------------------------
+    // Freeze / unfreeze
+    // -------------------------------------------------------------------------
+
+    /// @notice Freeze every operation on a market.
+    function freezeMarket(address market, string calldata reason) external onlyFreezer {
+        _freeze(market, OP_ALL, reason);
+    }
+
+    /// @notice Freeze a single operation on a market (e.g. only withdrawals).
+    function freezeOperation(address market, bytes32 operation, string calldata reason) external onlyFreezer {
+        _freeze(market, operation, reason);
+    }
+
+    /// @notice Lift a market-wide freeze.
+    function unfreezeMarket(address market) external onlyFreezer {
+        _unfreeze(market, OP_ALL);
+    }
+
+    /// @notice Lift a per-operation freeze.
+    function unfreezeOperation(address market, bytes32 operation) external onlyFreezer {
+        _unfreeze(market, operation);
+    }
+
+    function _freeze(address market, bytes32 operation, string calldata reason) internal {
+        if (market == address(0)) revert InvalidMarket();
+        FreezeInfo storage info = _freezes[market][operation];
+        if (info.frozen) revert MarketAlreadyFrozen(operation);
+        info.frozen = true;
+        info.frozenBy = msg.sender;
+        info.frozenAt = uint64(block.timestamp);
+        info.reason = reason;
+        emit MarketFrozen(market, operation, msg.sender, reason);
+    }
+
+    function _unfreeze(address market, bytes32 operation) internal {
+        FreezeInfo storage info = _freezes[market][operation];
+        if (!info.frozen) revert MarketNotFrozen(operation);
+        info.frozen = false;
+        info.frozenBy = address(0);
+        info.frozenAt = 0;
+        info.reason = "";
+        emit MarketUnfrozen(market, operation, msg.sender);
+    }
+
+    // -------------------------------------------------------------------------
+    // Queries
+    // -------------------------------------------------------------------------
+
+    /// @notice Whether the entire market is frozen via OP_ALL.
+    function isMarketFrozen(address market) public view returns (bool) {
+        return _freezes[market][OP_ALL].frozen;
+    }
+
+    /// @notice Whether a specific operation is frozen.
+    /// @dev A market-wide OP_ALL freeze also counts as frozen for any operation.
+    function isOperationFrozen(address market, bytes32 operation) public view returns (bool) {
+        if (_freezes[market][OP_ALL].frozen) return true;
+        return _freezes[market][operation].frozen;
+    }
+
+    /// @notice Read the freeze record for a given operation.
+    function getFreezeInfo(address market, bytes32 operation) external view returns (FreezeInfo memory) {
+        return _freezes[market][operation];
+    }
+
+    /// @notice Convenience guard helper for downstream contracts.
+    function requireOperationAllowed(address market, bytes32 operation) external view {
+        if (isOperationFrozen(market, operation)) revert OperationFrozen(operation);
+    }
+}

--- a/Contracts/contracts/WithdrawalLimit.sol
+++ b/Contracts/contracts/WithdrawalLimit.sol
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title WithdrawalLimit
+/// @notice Per-user, per-token rolling-window withdrawal limit enforcement.
+/// @dev Tracks usage in fixed-length windows (default 24h) plus a single-tx cap.
+contract WithdrawalLimit is Ownable {
+    // -------------------------------------------------------------------------
+    // Custom errors
+    // -------------------------------------------------------------------------
+    error ZeroAddress();
+    error ZeroWindow();
+    error LimitExceeded(uint256 attempted, uint256 remaining);
+    error PerTxCapExceeded(uint256 attempted, uint256 cap);
+    error NotEnforcer();
+    error AlreadyEnforcer();
+
+    // -------------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------------
+    struct Limit {
+        uint256 windowAmount;   // total amount allowed per window (0 = no window cap)
+        uint256 perTxCap;       // max for a single record (0 = no per-tx cap)
+        uint64  windowSeconds;  // window length, e.g. 86_400
+        bool    set;            // explicitly configured
+    }
+
+    struct Usage {
+        uint256 amount;
+        uint64  windowStart;
+    }
+
+    // -------------------------------------------------------------------------
+    // Storage
+    // -------------------------------------------------------------------------
+    /// @dev token => default limit applied when no per-user override exists
+    mapping(address => Limit) private _defaultLimits;
+
+    /// @dev user => token => override limit
+    mapping(address => mapping(address => Limit)) private _userLimits;
+
+    /// @dev user => token => current rolling-window usage
+    mapping(address => mapping(address => Usage)) private _usage;
+
+    /// @dev addresses authorised to call `record`
+    mapping(address => bool) private _enforcers;
+    address[] private _enforcerList;
+
+    /// @dev default window length applied when a limit is configured without one
+    uint64 public constant DEFAULT_WINDOW = 1 days;
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+    event EnforcerAdded(address indexed enforcer);
+    event EnforcerRemoved(address indexed enforcer);
+    event DefaultLimitSet(address indexed token, uint256 windowAmount, uint256 perTxCap, uint64 windowSeconds);
+    event UserLimitSet(
+        address indexed user,
+        address indexed token,
+        uint256 windowAmount,
+        uint256 perTxCap,
+        uint64 windowSeconds
+    );
+    event UserLimitCleared(address indexed user, address indexed token);
+    event WithdrawalRecorded(address indexed user, address indexed token, uint256 amount, uint256 windowUsed);
+    event UsageReset(address indexed user, address indexed token);
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+    modifier onlyEnforcer() {
+        if (!_enforcers[msg.sender] && msg.sender != owner()) revert NotEnforcer();
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Enforcer registry
+    // -------------------------------------------------------------------------
+    function addEnforcer(address enforcer) external onlyOwner {
+        if (enforcer == address(0)) revert ZeroAddress();
+        if (_enforcers[enforcer]) revert AlreadyEnforcer();
+        _enforcers[enforcer] = true;
+        _enforcerList.push(enforcer);
+        emit EnforcerAdded(enforcer);
+    }
+
+    function removeEnforcer(address enforcer) external onlyOwner {
+        if (!_enforcers[enforcer]) revert NotEnforcer();
+        _enforcers[enforcer] = false;
+
+        uint256 len = _enforcerList.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (_enforcerList[i] == enforcer) {
+                _enforcerList[i] = _enforcerList[len - 1];
+                _enforcerList.pop();
+                break;
+            }
+        }
+        emit EnforcerRemoved(enforcer);
+    }
+
+    function isEnforcer(address account) external view returns (bool) {
+        return _enforcers[account];
+    }
+
+    // -------------------------------------------------------------------------
+    // Limit configuration
+    // -------------------------------------------------------------------------
+
+    /// @notice Configure the default limit applied to a token.
+    function setDefaultLimit(
+        address token,
+        uint256 windowAmount,
+        uint256 perTxCap,
+        uint64 windowSeconds
+    ) external onlyOwner {
+        if (token == address(0)) revert ZeroAddress();
+        _defaultLimits[token] = Limit({
+            windowAmount: windowAmount,
+            perTxCap: perTxCap,
+            windowSeconds: windowSeconds == 0 ? DEFAULT_WINDOW : windowSeconds,
+            set: true
+        });
+        emit DefaultLimitSet(token, windowAmount, perTxCap, windowSeconds);
+    }
+
+    /// @notice Override the limit for a specific user and token.
+    function setUserLimit(
+        address user,
+        address token,
+        uint256 windowAmount,
+        uint256 perTxCap,
+        uint64 windowSeconds
+    ) external onlyOwner {
+        if (user == address(0) || token == address(0)) revert ZeroAddress();
+        _userLimits[user][token] = Limit({
+            windowAmount: windowAmount,
+            perTxCap: perTxCap,
+            windowSeconds: windowSeconds == 0 ? DEFAULT_WINDOW : windowSeconds,
+            set: true
+        });
+        emit UserLimitSet(user, token, windowAmount, perTxCap, windowSeconds);
+    }
+
+    /// @notice Remove a per-user override; falls back to default.
+    function clearUserLimit(address user, address token) external onlyOwner {
+        delete _userLimits[user][token];
+        emit UserLimitCleared(user, token);
+    }
+
+    /// @notice Reset a user's usage counter for a token (e.g. after support review).
+    function resetUsage(address user, address token) external onlyOwner {
+        delete _usage[user][token];
+        emit UsageReset(user, token);
+    }
+
+    // -------------------------------------------------------------------------
+    // Enforcement
+    // -------------------------------------------------------------------------
+
+    /// @notice Reverts iff `amount` is over the configured limits for `user`/`token`.
+    /// @dev Pure preview helper that does not mutate usage.
+    function check(address user, address token, uint256 amount) public view {
+        Limit memory lim = effectiveLimit(user, token);
+
+        if (lim.perTxCap != 0 && amount > lim.perTxCap) {
+            revert PerTxCapExceeded(amount, lim.perTxCap);
+        }
+
+        if (lim.windowAmount == 0) return;
+
+        (uint256 used, ) = _projectUsage(user, token, lim.windowSeconds);
+        uint256 remaining = lim.windowAmount > used ? lim.windowAmount - used : 0;
+        if (amount > remaining) revert LimitExceeded(amount, remaining);
+    }
+
+    /// @notice Validate then commit a withdrawal against the rolling window.
+    /// @dev Callable only by enforcers (e.g. the vault contract).
+    function record(address user, address token, uint256 amount) external onlyEnforcer {
+        Limit memory lim = effectiveLimit(user, token);
+
+        if (lim.perTxCap != 0 && amount > lim.perTxCap) {
+            revert PerTxCapExceeded(amount, lim.perTxCap);
+        }
+
+        Usage storage u = _usage[user][token];
+        uint64 windowSec = lim.windowSeconds == 0 ? DEFAULT_WINDOW : lim.windowSeconds;
+
+        if (u.windowStart == 0 || block.timestamp >= uint256(u.windowStart) + windowSec) {
+            u.windowStart = uint64(block.timestamp);
+            u.amount = 0;
+        }
+
+        if (lim.windowAmount != 0) {
+            uint256 remaining = lim.windowAmount > u.amount ? lim.windowAmount - u.amount : 0;
+            if (amount > remaining) revert LimitExceeded(amount, remaining);
+        }
+
+        u.amount += amount;
+        emit WithdrawalRecorded(user, token, amount, u.amount);
+    }
+
+    // -------------------------------------------------------------------------
+    // Queries
+    // -------------------------------------------------------------------------
+
+    /// @notice The limit applied to a (user, token) pair: per-user override else default.
+    function effectiveLimit(address user, address token) public view returns (Limit memory) {
+        Limit memory lim = _userLimits[user][token];
+        if (lim.set) return lim;
+        return _defaultLimits[token];
+    }
+
+    function getDefaultLimit(address token) external view returns (Limit memory) {
+        return _defaultLimits[token];
+    }
+
+    function getUserLimit(address user, address token) external view returns (Limit memory) {
+        return _userLimits[user][token];
+    }
+
+    /// @notice Current rolling-window usage and remaining budget.
+    function getUsage(address user, address token)
+        external
+        view
+        returns (uint256 used, uint256 remaining, uint64 windowStart, uint64 windowEnd)
+    {
+        Limit memory lim = effectiveLimit(user, token);
+        uint64 windowSec = lim.windowSeconds == 0 ? DEFAULT_WINDOW : lim.windowSeconds;
+        (uint256 currentUsed, uint64 start) = _projectUsage(user, token, windowSec);
+        used = currentUsed;
+        if (lim.windowAmount == 0) {
+            remaining = type(uint256).max;
+        } else {
+            remaining = lim.windowAmount > used ? lim.windowAmount - used : 0;
+        }
+        windowStart = start;
+        windowEnd = start == 0 ? 0 : start + windowSec;
+    }
+
+    /// @notice Convenience: amount the user may still withdraw right now.
+    function remaining(address user, address token) external view returns (uint256) {
+        Limit memory lim = effectiveLimit(user, token);
+        if (lim.windowAmount == 0) return type(uint256).max;
+        uint64 windowSec = lim.windowSeconds == 0 ? DEFAULT_WINDOW : lim.windowSeconds;
+        (uint256 used, ) = _projectUsage(user, token, windowSec);
+        return lim.windowAmount > used ? lim.windowAmount - used : 0;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    /// @dev Read usage as of `block.timestamp`, treating expired windows as reset.
+    function _projectUsage(address user, address token, uint64 windowSec)
+        internal
+        view
+        returns (uint256 used, uint64 windowStart)
+    {
+        Usage storage u = _usage[user][token];
+        if (u.windowStart == 0) return (0, 0);
+        if (block.timestamp >= uint256(u.windowStart) + windowSec) {
+            return (0, 0);
+        }
+        return (u.amount, u.windowStart);
+    }
+}

--- a/Contracts/contracts/WithdrawalQueue.sol
+++ b/Contracts/contracts/WithdrawalQueue.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title WithdrawalQueue
+/// @notice FIFO withdrawal request queue with cancellation and ordered processing.
+contract WithdrawalQueue is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // -------------------------------------------------------------------------
+    // Custom errors
+    // -------------------------------------------------------------------------
+    error ZeroAddress();
+    error ZeroAmount();
+    error UnknownRequest();
+    error NotRequestOwner();
+    error InvalidStatus();
+    error QueueEmpty();
+    error NotProcessor();
+    error AlreadyProcessor();
+
+    // -------------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------------
+    enum Status { NONE, PENDING, PROCESSED, CANCELLED }
+
+    struct Request {
+        uint256 id;
+        address user;
+        IERC20 token;
+        uint256 amount;
+        uint64 requestedAt;
+        uint64 settledAt;
+        Status status;
+    }
+
+    // -------------------------------------------------------------------------
+    // Storage
+    // -------------------------------------------------------------------------
+    uint256 private _nextId = 1;
+
+    /// @dev id => request
+    mapping(uint256 => Request) private _requests;
+
+    /// @dev FIFO order of pending request ids
+    uint256[] private _queue;
+    /// @dev id => index in `_queue` (1-based; 0 means "not in queue")
+    mapping(uint256 => uint256) private _queueIndexPlusOne;
+
+    /// @dev user => list of their request ids
+    mapping(address => uint256[]) private _userRequests;
+
+    /// @dev addresses authorised to call `processNext`
+    mapping(address => bool) private _processors;
+    address[] private _processorList;
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+    event ProcessorAdded(address indexed processor);
+    event ProcessorRemoved(address indexed processor);
+    event WithdrawalRequested(
+        uint256 indexed id,
+        address indexed user,
+        address indexed token,
+        uint256 amount
+    );
+    event WithdrawalProcessed(uint256 indexed id, address indexed user, uint256 amount);
+    event WithdrawalCancelled(uint256 indexed id, address indexed user);
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+    modifier onlyProcessor() {
+        if (!_processors[msg.sender] && msg.sender != owner()) revert NotProcessor();
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Processor registry
+    // -------------------------------------------------------------------------
+    function addProcessor(address processor) external onlyOwner {
+        if (processor == address(0)) revert ZeroAddress();
+        if (_processors[processor]) revert AlreadyProcessor();
+        _processors[processor] = true;
+        _processorList.push(processor);
+        emit ProcessorAdded(processor);
+    }
+
+    function removeProcessor(address processor) external onlyOwner {
+        if (!_processors[processor]) revert NotProcessor();
+        _processors[processor] = false;
+
+        uint256 len = _processorList.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (_processorList[i] == processor) {
+                _processorList[i] = _processorList[len - 1];
+                _processorList.pop();
+                break;
+            }
+        }
+        emit ProcessorRemoved(processor);
+    }
+
+    function isProcessor(address account) external view returns (bool) {
+        return _processors[account];
+    }
+
+    // -------------------------------------------------------------------------
+    // User actions
+    // -------------------------------------------------------------------------
+
+    /// @notice Submit a withdrawal request. Caller's tokens must be available
+    ///         off-contract (e.g. via vault accounting); this contract only
+    ///         tracks order & metadata.
+    function request(IERC20 token, uint256 amount) external returns (uint256 id) {
+        if (address(token) == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+
+        id = _nextId++;
+        _requests[id] = Request({
+            id: id,
+            user: msg.sender,
+            token: token,
+            amount: amount,
+            requestedAt: uint64(block.timestamp),
+            settledAt: 0,
+            status: Status.PENDING
+        });
+
+        _queue.push(id);
+        _queueIndexPlusOne[id] = _queue.length;
+        _userRequests[msg.sender].push(id);
+
+        emit WithdrawalRequested(id, msg.sender, address(token), amount);
+    }
+
+    /// @notice Cancel a pending request. Only the original requester may call.
+    function cancel(uint256 id) external nonReentrant {
+        Request storage r = _requests[id];
+        if (r.status == Status.NONE) revert UnknownRequest();
+        if (r.user != msg.sender) revert NotRequestOwner();
+        if (r.status != Status.PENDING) revert InvalidStatus();
+
+        r.status = Status.CANCELLED;
+        r.settledAt = uint64(block.timestamp);
+        _removeFromQueue(id);
+
+        emit WithdrawalCancelled(id, msg.sender);
+    }
+
+    // -------------------------------------------------------------------------
+    // Processor actions
+    // -------------------------------------------------------------------------
+
+    /// @notice Settle the next pending request in FIFO order, paying the user
+    ///         from this contract's token balance.
+    function processNext() external nonReentrant onlyProcessor returns (uint256 id) {
+        if (_queue.length == 0) revert QueueEmpty();
+        id = _queue[0];
+        Request storage r = _requests[id];
+        // Skip past any cancelled entries that linger at the head (defensive;
+        // _removeFromQueue keeps the queue clean, but be safe).
+        while (r.status != Status.PENDING) {
+            _popFront();
+            if (_queue.length == 0) revert QueueEmpty();
+            id = _queue[0];
+            r = _requests[id];
+        }
+
+        r.status = Status.PROCESSED;
+        r.settledAt = uint64(block.timestamp);
+        _popFront();
+
+        r.token.safeTransfer(r.user, r.amount);
+        emit WithdrawalProcessed(id, r.user, r.amount);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal queue helpers
+    // -------------------------------------------------------------------------
+
+    function _popFront() internal {
+        uint256 id = _queue[0];
+        uint256 last = _queue.length - 1;
+        if (last != 0) {
+            uint256 lastId = _queue[last];
+            _queue[0] = lastId;
+            _queueIndexPlusOne[lastId] = 1;
+        }
+        _queue.pop();
+        _queueIndexPlusOne[id] = 0;
+    }
+
+    function _removeFromQueue(uint256 id) internal {
+        uint256 idxPlusOne = _queueIndexPlusOne[id];
+        if (idxPlusOne == 0) return;
+        uint256 idx = idxPlusOne - 1;
+        uint256 last = _queue.length - 1;
+        if (idx != last) {
+            uint256 lastId = _queue[last];
+            _queue[idx] = lastId;
+            _queueIndexPlusOne[lastId] = idx + 1;
+        }
+        _queue.pop();
+        _queueIndexPlusOne[id] = 0;
+    }
+
+    // -------------------------------------------------------------------------
+    // Queries
+    // -------------------------------------------------------------------------
+
+    function getRequest(uint256 id) external view returns (Request memory) {
+        return _requests[id];
+    }
+
+    function statusOf(uint256 id) external view returns (Status) {
+        return _requests[id].status;
+    }
+
+    /// @notice Length of the active pending queue.
+    function queueLength() external view returns (uint256) {
+        return _queue.length;
+    }
+
+    /// @notice Read the next request id without removing it.
+    function head() external view returns (uint256) {
+        if (_queue.length == 0) revert QueueEmpty();
+        return _queue[0];
+    }
+
+    /// @notice Snapshot of current pending request ids in FIFO order.
+    function pendingIds() external view returns (uint256[] memory) {
+        return _queue;
+    }
+
+    /// @notice All request ids submitted by `user` (any status).
+    function userRequests(address user) external view returns (uint256[] memory) {
+        return _userRequests[user];
+    }
+}

--- a/Contracts/test/KYCStorage.t.sol
+++ b/Contracts/test/KYCStorage.t.sol
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/KYCStorage.sol";
+
+contract KYCStorageTest is Test {
+    KYCStorage kyc;
+
+    address owner = address(0xA11CE);
+    address verifier = address(0xBEEF);
+    address verifier2 = address(0xCAFE);
+    address user = address(0xD00D);
+    address user2 = address(0xFADE);
+
+    function setUp() public {
+        kyc = new KYCStorage(owner);
+        vm.prank(owner);
+        kyc.addVerifier(verifier);
+    }
+
+    // ------- verifier management -------
+
+    function test_OwnerCanAddAndRemoveVerifier() public {
+        vm.prank(owner);
+        kyc.addVerifier(verifier2);
+        assertTrue(kyc.isVerifier(verifier2));
+
+        vm.prank(owner);
+        kyc.removeVerifier(verifier2);
+        assertFalse(kyc.isVerifier(verifier2));
+    }
+
+    function test_NonOwnerCannotAddVerifier() public {
+        vm.prank(user);
+        vm.expectRevert();
+        kyc.addVerifier(verifier2);
+    }
+
+    function test_CannotAddZeroVerifier() public {
+        vm.prank(owner);
+        vm.expectRevert(KYCStorage.ZeroAddress.selector);
+        kyc.addVerifier(address(0));
+    }
+
+    function test_CannotAddVerifierTwice() public {
+        vm.prank(owner);
+        vm.expectRevert(KYCStorage.AlreadyVerifier.selector);
+        kyc.addVerifier(verifier);
+    }
+
+    function test_CannotRemoveUnknownVerifier() public {
+        vm.prank(owner);
+        vm.expectRevert(KYCStorage.NotVerifier.selector);
+        kyc.removeVerifier(verifier2);
+    }
+
+    function test_GetVerifiersReturnsRegisteredAccounts() public {
+        vm.prank(owner);
+        kyc.addVerifier(verifier2);
+        address[] memory list = kyc.getVerifiers();
+        assertEq(list.length, 2);
+    }
+
+    // ------- submission and verification -------
+
+    function test_UserSubmitMarksPending() public {
+        vm.prank(user);
+        kyc.submit(keccak256("docs"), "US");
+
+        KYCStorage.Record memory rec = kyc.getRecord(user);
+        assertEq(uint8(rec.status), uint8(KYCStorage.Status.PENDING));
+        assertEq(rec.documentHash, keccak256("docs"));
+        assertEq(rec.jurisdiction, "US");
+        assertGt(uint256(rec.updatedAt), 0);
+    }
+
+    function test_VerifierCanSetVerified() public {
+        vm.prank(user);
+        kyc.submit(keccak256("docs"), "US");
+
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 2, uint64(block.timestamp + 365 days));
+
+        KYCStorage.Record memory rec = kyc.getRecord(user);
+        assertEq(uint8(rec.status), uint8(KYCStorage.Status.VERIFIED));
+        assertEq(rec.level, 2);
+        assertEq(rec.verifier, verifier);
+        assertGt(uint256(rec.verifiedAt), 0);
+    }
+
+    function test_NonVerifierCannotSetVerification() public {
+        vm.prank(user2);
+        vm.expectRevert(KYCStorage.NotVerifier.selector);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 1, 0);
+    }
+
+    function test_CannotSetStatusNone() public {
+        vm.prank(verifier);
+        vm.expectRevert(KYCStorage.InvalidStatus.selector);
+        kyc.setVerification(user, KYCStorage.Status.NONE, 1, 0);
+    }
+
+    function test_CannotSetInvalidLevel() public {
+        vm.prank(verifier);
+        vm.expectRevert(KYCStorage.InvalidLevel.selector);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 4, 0);
+    }
+
+    function test_CannotSetForZeroAddress() public {
+        vm.prank(verifier);
+        vm.expectRevert(KYCStorage.ZeroAddress.selector);
+        kyc.setVerification(address(0), KYCStorage.Status.VERIFIED, 1, 0);
+    }
+
+    function test_RevokeChangesStatus() public {
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 1, 0);
+
+        vm.prank(verifier);
+        kyc.revoke(user, "fraud");
+
+        KYCStorage.Record memory rec = kyc.getRecord(user);
+        assertEq(uint8(rec.status), uint8(KYCStorage.Status.REVOKED));
+    }
+
+    function test_CannotRevokeUnknownRecord() public {
+        vm.prank(verifier);
+        vm.expectRevert(KYCStorage.UnknownRecord.selector);
+        kyc.revoke(user, "missing");
+    }
+
+    // ------- query semantics -------
+
+    function test_StatusOfReportsExpiredAfterTimestamp() public {
+        uint64 expiry = uint64(block.timestamp + 100);
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 1, expiry);
+
+        assertEq(uint8(kyc.statusOf(user)), uint8(KYCStorage.Status.VERIFIED));
+
+        vm.warp(uint256(expiry));
+        assertEq(uint8(kyc.statusOf(user)), uint8(KYCStorage.Status.EXPIRED));
+    }
+
+    function test_StatusOfWithoutExpiryStaysVerified() public {
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 1, 0);
+        vm.warp(block.timestamp + 365 days);
+        assertEq(uint8(kyc.statusOf(user)), uint8(KYCStorage.Status.VERIFIED));
+    }
+
+    function test_IsVerifiedRequiresMinLevel() public {
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 1, 0);
+
+        assertTrue(kyc.isVerified(user, 1));
+        assertFalse(kyc.isVerified(user, 2));
+    }
+
+    function test_IsVerifiedFalseAfterExpiry() public {
+        uint64 expiry = uint64(block.timestamp + 10);
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 2, expiry);
+
+        vm.warp(uint256(expiry) + 1);
+        assertFalse(kyc.isVerified(user, 1));
+    }
+
+    function test_IsVerifiedFalseWhenRejected() public {
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.REJECTED, 0, 0);
+        assertFalse(kyc.isVerified(user, 0));
+    }
+
+    function test_ExpiryOf() public {
+        uint64 expiry = uint64(block.timestamp + 5 days);
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 1, expiry);
+        assertEq(kyc.expiryOf(user), expiry);
+    }
+
+    function test_UserListAndPagination() public {
+        vm.prank(user);
+        kyc.submit(keccak256("a"), "US");
+        vm.prank(user2);
+        kyc.submit(keccak256("b"), "GB");
+
+        assertEq(kyc.userCount(), 2);
+        address[] memory page = kyc.listUsers(0, 10);
+        assertEq(page.length, 2);
+
+        address[] memory empty = kyc.listUsers(5, 10);
+        assertEq(empty.length, 0);
+
+        address[] memory firstOnly = kyc.listUsers(0, 1);
+        assertEq(firstOnly.length, 1);
+        assertEq(firstOnly[0], user);
+    }
+
+    function test_VerifierWriteRegistersUserOnce() public {
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 1, 0);
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 2, 0);
+        assertEq(kyc.userCount(), 1);
+    }
+
+    function test_UpdateOverwritesPriorRecord() public {
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 1, 0);
+
+        vm.prank(verifier);
+        kyc.setVerification(user, KYCStorage.Status.VERIFIED, 3, uint64(block.timestamp + 1000));
+
+        KYCStorage.Record memory rec = kyc.getRecord(user);
+        assertEq(rec.level, 3);
+        assertEq(rec.expiresAt, uint64(block.timestamp + 1000));
+    }
+}

--- a/Contracts/test/MarketFreeze.t.sol
+++ b/Contracts/test/MarketFreeze.t.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/MarketFreeze.sol";
+
+contract MarketFreezeTest is Test {
+    MarketFreeze freeze;
+
+    address owner = address(0xA11CE);
+    address freezer = address(0xBEEF);
+    address other = address(0xCAFE);
+    address market = address(0xAAAA);
+    address market2 = address(0xBBBB);
+
+    function setUp() public {
+        freeze = new MarketFreeze(owner);
+        vm.prank(owner);
+        freeze.addFreezer(freezer);
+    }
+
+    // ------- freezer registry -------
+
+    function test_OwnerAddRemoveFreezer() public {
+        address f = address(0xF11);
+        vm.prank(owner);
+        freeze.addFreezer(f);
+        assertTrue(freeze.isFreezer(f));
+
+        vm.prank(owner);
+        freeze.removeFreezer(f);
+        assertFalse(freeze.isFreezer(f));
+    }
+
+    function test_NonOwnerCannotAddFreezer() public {
+        vm.prank(other);
+        vm.expectRevert();
+        freeze.addFreezer(address(0xF1));
+    }
+
+    function test_CannotAddZeroFreezer() public {
+        vm.prank(owner);
+        vm.expectRevert(MarketFreeze.ZeroAddress.selector);
+        freeze.addFreezer(address(0));
+    }
+
+    function test_CannotAddDuplicateFreezer() public {
+        vm.prank(owner);
+        vm.expectRevert(MarketFreeze.AlreadyFreezer.selector);
+        freeze.addFreezer(freezer);
+    }
+
+    function test_CannotRemoveUnknownFreezer() public {
+        vm.prank(owner);
+        vm.expectRevert(MarketFreeze.NotFreezer.selector);
+        freeze.removeFreezer(other);
+    }
+
+    function test_GetFreezersList() public {
+        vm.prank(owner);
+        freeze.addFreezer(other);
+        address[] memory list = freeze.getFreezers();
+        assertEq(list.length, 2);
+    }
+
+    // ------- market-wide freeze -------
+
+    function test_FreezeMarket() public {
+        vm.prank(freezer);
+        freeze.freezeMarket(market, "exploit drill");
+
+        assertTrue(freeze.isMarketFrozen(market));
+        assertTrue(freeze.isOperationFrozen(market, freeze.OP_TRADE()));
+    }
+
+    function test_NonFreezerCannotFreeze() public {
+        vm.prank(other);
+        vm.expectRevert(MarketFreeze.NotFreezer.selector);
+        freeze.freezeMarket(market, "x");
+    }
+
+    function test_OwnerCanFreezeWithoutBeingFreezer() public {
+        vm.prank(owner);
+        freeze.freezeMarket(market, "ad-hoc");
+        assertTrue(freeze.isMarketFrozen(market));
+    }
+
+    function test_CannotFreezeZeroMarket() public {
+        vm.prank(freezer);
+        vm.expectRevert(MarketFreeze.InvalidMarket.selector);
+        freeze.freezeMarket(address(0), "x");
+    }
+
+    function test_CannotFreezeTwice() public {
+        vm.prank(freezer);
+        freeze.freezeMarket(market, "first");
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSelector(MarketFreeze.MarketAlreadyFrozen.selector, freeze.OP_ALL()));
+        freeze.freezeMarket(market, "second");
+    }
+
+    function test_UnfreezeMarket() public {
+        vm.prank(freezer);
+        freeze.freezeMarket(market, "x");
+        vm.prank(freezer);
+        freeze.unfreezeMarket(market);
+
+        assertFalse(freeze.isMarketFrozen(market));
+        assertFalse(freeze.isOperationFrozen(market, freeze.OP_TRADE()));
+    }
+
+    function test_CannotUnfreezeIfNotFrozen() public {
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSelector(MarketFreeze.MarketNotFrozen.selector, freeze.OP_ALL()));
+        freeze.unfreezeMarket(market);
+    }
+
+    // ------- selective operation freeze -------
+
+    function test_SelectiveFreezeOnlyAffectsOneOp() public {
+        vm.prank(freezer);
+        freeze.freezeOperation(market, freeze.OP_WITHDRAW(), "rate-limit");
+
+        assertTrue(freeze.isOperationFrozen(market, freeze.OP_WITHDRAW()));
+        assertFalse(freeze.isOperationFrozen(market, freeze.OP_TRADE()));
+        assertFalse(freeze.isMarketFrozen(market));
+    }
+
+    function test_OpAllFreezeOverridesOpQuery() public {
+        vm.prank(freezer);
+        freeze.freezeMarket(market, "kill");
+
+        assertTrue(freeze.isOperationFrozen(market, freeze.OP_DEPOSIT()));
+        assertTrue(freeze.isOperationFrozen(market, freeze.OP_RESOLVE()));
+    }
+
+    function test_UnfreezeSelectiveLeavesOthers() public {
+        bytes32 wOp = freeze.OP_WITHDRAW();
+        bytes32 tOp = freeze.OP_TRADE();
+
+        vm.startPrank(freezer);
+        freeze.freezeOperation(market, wOp, "w");
+        freeze.freezeOperation(market, tOp, "t");
+        freeze.unfreezeOperation(market, wOp);
+        vm.stopPrank();
+
+        assertFalse(freeze.isOperationFrozen(market, wOp));
+        assertTrue(freeze.isOperationFrozen(market, tOp));
+    }
+
+    function test_FreezeIsolationBetweenMarkets() public {
+        vm.prank(freezer);
+        freeze.freezeMarket(market, "isolated");
+
+        assertTrue(freeze.isMarketFrozen(market));
+        assertFalse(freeze.isMarketFrozen(market2));
+        assertFalse(freeze.isOperationFrozen(market2, freeze.OP_TRADE()));
+    }
+
+    // ------- guards & metadata -------
+
+    function test_RequireOperationAllowedReverts() public {
+        vm.prank(freezer);
+        freeze.freezeOperation(market, freeze.OP_TRADE(), "halt");
+
+        vm.expectRevert(abi.encodeWithSelector(MarketFreeze.OperationFrozen.selector, freeze.OP_TRADE()));
+        freeze.requireOperationAllowed(market, freeze.OP_TRADE());
+    }
+
+    function test_RequireOperationAllowedPasses() public view {
+        freeze.requireOperationAllowed(market, freeze.OP_TRADE());
+    }
+
+    function test_GetFreezeInfoCarriesMetadata() public {
+        vm.prank(freezer);
+        freeze.freezeMarket(market, "incident-42");
+
+        MarketFreeze.FreezeInfo memory info = freeze.getFreezeInfo(market, freeze.OP_ALL());
+        assertTrue(info.frozen);
+        assertEq(info.frozenBy, freezer);
+        assertEq(info.reason, "incident-42");
+        assertGt(uint256(info.frozenAt), 0);
+    }
+
+    function test_UnfreezeClearsMetadata() public {
+        vm.startPrank(freezer);
+        freeze.freezeMarket(market, "x");
+        freeze.unfreezeMarket(market);
+        vm.stopPrank();
+
+        MarketFreeze.FreezeInfo memory info = freeze.getFreezeInfo(market, freeze.OP_ALL());
+        assertFalse(info.frozen);
+        assertEq(info.frozenBy, address(0));
+    }
+}

--- a/Contracts/test/WithdrawalLimit.t.sol
+++ b/Contracts/test/WithdrawalLimit.t.sol
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/WithdrawalLimit.sol";
+
+contract WithdrawalLimitTest is Test {
+    WithdrawalLimit limits;
+
+    address owner = address(0xA11CE);
+    address enforcer = address(0xBEEF);
+    address user1 = address(0xCAFE);
+    address user2 = address(0xD00D);
+    address tokenA = address(0xAAAA);
+    address tokenB = address(0xBBBB);
+
+    function setUp() public {
+        limits = new WithdrawalLimit(owner);
+        vm.prank(owner);
+        limits.addEnforcer(enforcer);
+    }
+
+    // ------- enforcer registry -------
+
+    function test_OwnerAddRemoveEnforcer() public {
+        address e = address(0xE11);
+        vm.prank(owner);
+        limits.addEnforcer(e);
+        assertTrue(limits.isEnforcer(e));
+
+        vm.prank(owner);
+        limits.removeEnforcer(e);
+        assertFalse(limits.isEnforcer(e));
+    }
+
+    function test_NonOwnerCannotAddEnforcer() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        limits.addEnforcer(address(0xE11));
+    }
+
+    function test_CannotAddZeroEnforcer() public {
+        vm.prank(owner);
+        vm.expectRevert(WithdrawalLimit.ZeroAddress.selector);
+        limits.addEnforcer(address(0));
+    }
+
+    function test_CannotAddDuplicateEnforcer() public {
+        vm.prank(owner);
+        vm.expectRevert(WithdrawalLimit.AlreadyEnforcer.selector);
+        limits.addEnforcer(enforcer);
+    }
+
+    // ------- limit configuration -------
+
+    function test_SetDefaultLimit() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 1_000 ether, 250 ether, 0);
+
+        WithdrawalLimit.Limit memory lim = limits.getDefaultLimit(tokenA);
+        assertTrue(lim.set);
+        assertEq(lim.windowAmount, 1_000 ether);
+        assertEq(lim.perTxCap, 250 ether);
+        assertEq(lim.windowSeconds, limits.DEFAULT_WINDOW());
+    }
+
+    function test_SetDefaultLimitRespectsCustomWindow() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 100, 0, 3600);
+        assertEq(limits.getDefaultLimit(tokenA).windowSeconds, 3600);
+    }
+
+    function test_SetUserLimitOverridesDefault() public {
+        vm.startPrank(owner);
+        limits.setDefaultLimit(tokenA, 1_000, 0, 0);
+        limits.setUserLimit(user1, tokenA, 500, 0, 0);
+        vm.stopPrank();
+
+        WithdrawalLimit.Limit memory eff = limits.effectiveLimit(user1, tokenA);
+        assertEq(eff.windowAmount, 500);
+
+        WithdrawalLimit.Limit memory other = limits.effectiveLimit(user2, tokenA);
+        assertEq(other.windowAmount, 1_000);
+    }
+
+    function test_ClearUserLimitFallsBackToDefault() public {
+        vm.startPrank(owner);
+        limits.setDefaultLimit(tokenA, 1_000, 0, 0);
+        limits.setUserLimit(user1, tokenA, 500, 0, 0);
+        limits.clearUserLimit(user1, tokenA);
+        vm.stopPrank();
+
+        assertEq(limits.effectiveLimit(user1, tokenA).windowAmount, 1_000);
+    }
+
+    function test_NonOwnerCannotConfigure() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        limits.setDefaultLimit(tokenA, 1, 0, 0);
+    }
+
+    // ------- enforcement -------
+
+    function test_RecordWithinLimitSucceeds() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 100 ether, 0, 0);
+
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, 60 ether);
+
+        (uint256 used, uint256 rem, , ) = limits.getUsage(user1, tokenA);
+        assertEq(used, 60 ether);
+        assertEq(rem, 40 ether);
+    }
+
+    function test_RecordExceedingWindowReverts() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 100 ether, 0, 0);
+
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, 80 ether);
+
+        vm.prank(enforcer);
+        vm.expectRevert(abi.encodeWithSelector(WithdrawalLimit.LimitExceeded.selector, 30 ether, 20 ether));
+        limits.record(user1, tokenA, 30 ether);
+    }
+
+    function test_PerTxCapEnforced() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 1_000 ether, 100 ether, 0);
+
+        vm.prank(enforcer);
+        vm.expectRevert(abi.encodeWithSelector(WithdrawalLimit.PerTxCapExceeded.selector, 150 ether, 100 ether));
+        limits.record(user1, tokenA, 150 ether);
+    }
+
+    function test_NoLimitConfiguredAllowsAnyAmount() public {
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, type(uint128).max);
+        // no revert means pass
+        (uint256 used, , , ) = limits.getUsage(user1, tokenA);
+        assertEq(used, 0); // no window configured -> not tracked toward a budget
+    }
+
+    function test_NonEnforcerCannotRecord() public {
+        vm.prank(user2);
+        vm.expectRevert(WithdrawalLimit.NotEnforcer.selector);
+        limits.record(user1, tokenA, 1);
+    }
+
+    function test_OwnerCanRecordWithoutBeingEnforcer() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 100, 0, 0);
+        vm.prank(owner);
+        limits.record(user1, tokenA, 10);
+
+        (uint256 used, , , ) = limits.getUsage(user1, tokenA);
+        assertEq(used, 10);
+    }
+
+    // ------- window roll & resets -------
+
+    function test_WindowRollsAfterDuration() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 100, 0, 1 hours);
+
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, 100);
+
+        (uint256 used, uint256 rem, , uint64 windowEnd) = limits.getUsage(user1, tokenA);
+        assertEq(used, 100);
+        assertEq(rem, 0);
+
+        vm.warp(uint256(windowEnd) + 1);
+
+        // new window: should allow another 100
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, 100);
+
+        (used, rem, , ) = limits.getUsage(user1, tokenA);
+        assertEq(used, 100);
+        assertEq(rem, 0);
+    }
+
+    function test_RemainingHelper() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 50, 0, 0);
+
+        assertEq(limits.remaining(user1, tokenA), 50);
+
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, 30);
+        assertEq(limits.remaining(user1, tokenA), 20);
+    }
+
+    function test_RemainingIsMaxWhenUnconfigured() public view {
+        assertEq(limits.remaining(user1, tokenA), type(uint256).max);
+    }
+
+    function test_ResetUsageClears() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 100, 0, 0);
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, 100);
+
+        vm.prank(owner);
+        limits.resetUsage(user1, tokenA);
+
+        (uint256 used, uint256 rem, , ) = limits.getUsage(user1, tokenA);
+        assertEq(used, 0);
+        assertEq(rem, 100);
+    }
+
+    // ------- check() preview -------
+
+    function test_CheckMatchesRecord() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 100, 80, 0);
+
+        // within both caps
+        limits.check(user1, tokenA, 50);
+
+        // over per-tx cap
+        vm.expectRevert(abi.encodeWithSelector(WithdrawalLimit.PerTxCapExceeded.selector, 90, 80));
+        limits.check(user1, tokenA, 90);
+
+        // commit some usage and re-check window enforcement
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, 60);
+
+        // 50 fits per-tx cap (80) but only 40 remains in the window
+        vm.expectRevert(abi.encodeWithSelector(WithdrawalLimit.LimitExceeded.selector, 50, 40));
+        limits.check(user1, tokenA, 50);
+    }
+
+    function test_PerTokenIsolation() public {
+        vm.prank(owner);
+        limits.setDefaultLimit(tokenA, 100, 0, 0);
+
+        vm.prank(enforcer);
+        limits.record(user1, tokenA, 100);
+
+        // tokenB has no limit, should not be affected by tokenA usage
+        assertEq(limits.remaining(user1, tokenB), type(uint256).max);
+        vm.prank(enforcer);
+        limits.record(user1, tokenB, 999);
+    }
+}

--- a/Contracts/test/WithdrawalQueue.t.sol
+++ b/Contracts/test/WithdrawalQueue.t.sol
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../contracts/WithdrawalQueue.sol";
+
+/// @dev Minimal mintable ERC20 used for queue settlement tests.
+contract MockERC20 is IERC20 {
+    string public name = "Mock";
+    string public symbol = "MCK";
+    uint8 public constant decimals = 18;
+    uint256 public override totalSupply;
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function transfer(address to, uint256 amount) external override returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
+        uint256 a = allowance[from][msg.sender];
+        if (a != type(uint256).max) {
+            allowance[from][msg.sender] = a - amount;
+        }
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}
+
+contract WithdrawalQueueTest is Test {
+    WithdrawalQueue queue;
+    MockERC20 token;
+
+    address owner = address(0xA11CE);
+    address processor = address(0xBEEF);
+    address user1 = address(0xCAFE);
+    address user2 = address(0xD00D);
+
+    function setUp() public {
+        queue = new WithdrawalQueue(owner);
+        token = new MockERC20();
+        vm.prank(owner);
+        queue.addProcessor(processor);
+
+        // pre-fund the queue contract so it can pay out
+        token.mint(address(queue), 1_000 ether);
+    }
+
+    // ------- processor registry -------
+
+    function test_OwnerAddRemoveProcessor() public {
+        address p = address(0xBADD);
+        vm.prank(owner);
+        queue.addProcessor(p);
+        assertTrue(queue.isProcessor(p));
+
+        vm.prank(owner);
+        queue.removeProcessor(p);
+        assertFalse(queue.isProcessor(p));
+    }
+
+    function test_NonOwnerCannotAddProcessor() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        queue.addProcessor(address(0xBADD));
+    }
+
+    function test_CannotAddZeroProcessor() public {
+        vm.prank(owner);
+        vm.expectRevert(WithdrawalQueue.ZeroAddress.selector);
+        queue.addProcessor(address(0));
+    }
+
+    function test_CannotAddDuplicateProcessor() public {
+        vm.prank(owner);
+        vm.expectRevert(WithdrawalQueue.AlreadyProcessor.selector);
+        queue.addProcessor(processor);
+    }
+
+    // ------- request -------
+
+    function test_RequestEnqueues() public {
+        vm.prank(user1);
+        uint256 id = queue.request(token, 100 ether);
+
+        assertEq(id, 1);
+        assertEq(queue.queueLength(), 1);
+        assertEq(queue.head(), id);
+        assertEq(uint8(queue.statusOf(id)), uint8(WithdrawalQueue.Status.PENDING));
+    }
+
+    function test_RequestRevertsOnZeroAmount() public {
+        vm.prank(user1);
+        vm.expectRevert(WithdrawalQueue.ZeroAmount.selector);
+        queue.request(token, 0);
+    }
+
+    function test_RequestRevertsOnZeroToken() public {
+        vm.prank(user1);
+        vm.expectRevert(WithdrawalQueue.ZeroAddress.selector);
+        queue.request(IERC20(address(0)), 1 ether);
+    }
+
+    function test_MultipleRequestsAssignIncreasingIds() public {
+        vm.prank(user1);
+        uint256 id1 = queue.request(token, 50 ether);
+        vm.prank(user2);
+        uint256 id2 = queue.request(token, 25 ether);
+
+        assertEq(id1, 1);
+        assertEq(id2, 2);
+        assertEq(queue.queueLength(), 2);
+    }
+
+    // ------- ordered processing -------
+
+    function test_ProcessNextIsFifo() public {
+        vm.prank(user1);
+        uint256 id1 = queue.request(token, 50 ether);
+        vm.prank(user2);
+        uint256 id2 = queue.request(token, 25 ether);
+
+        uint256 user1Before = token.balanceOf(user1);
+        uint256 user2Before = token.balanceOf(user2);
+
+        vm.prank(processor);
+        uint256 processed = queue.processNext();
+        assertEq(processed, id1);
+        assertEq(token.balanceOf(user1) - user1Before, 50 ether);
+        assertEq(uint8(queue.statusOf(id1)), uint8(WithdrawalQueue.Status.PROCESSED));
+
+        vm.prank(processor);
+        processed = queue.processNext();
+        assertEq(processed, id2);
+        assertEq(token.balanceOf(user2) - user2Before, 25 ether);
+    }
+
+    function test_NonProcessorCannotProcess() public {
+        vm.prank(user1);
+        queue.request(token, 1 ether);
+
+        vm.prank(user2);
+        vm.expectRevert(WithdrawalQueue.NotProcessor.selector);
+        queue.processNext();
+    }
+
+    function test_OwnerCanProcessWithoutBeingProcessor() public {
+        vm.prank(user1);
+        queue.request(token, 1 ether);
+        vm.prank(owner);
+        queue.processNext();
+    }
+
+    function test_ProcessNextOnEmptyReverts() public {
+        vm.prank(processor);
+        vm.expectRevert(WithdrawalQueue.QueueEmpty.selector);
+        queue.processNext();
+    }
+
+    // ------- cancellation -------
+
+    function test_OwnerOfRequestCanCancel() public {
+        vm.prank(user1);
+        uint256 id = queue.request(token, 10 ether);
+
+        vm.prank(user1);
+        queue.cancel(id);
+
+        assertEq(uint8(queue.statusOf(id)), uint8(WithdrawalQueue.Status.CANCELLED));
+        assertEq(queue.queueLength(), 0);
+    }
+
+    function test_NonOwnerCannotCancel() public {
+        vm.prank(user1);
+        uint256 id = queue.request(token, 10 ether);
+
+        vm.prank(user2);
+        vm.expectRevert(WithdrawalQueue.NotRequestOwner.selector);
+        queue.cancel(id);
+    }
+
+    function test_CannotCancelUnknown() public {
+        vm.prank(user1);
+        vm.expectRevert(WithdrawalQueue.UnknownRequest.selector);
+        queue.cancel(99);
+    }
+
+    function test_CannotCancelTwice() public {
+        vm.prank(user1);
+        uint256 id = queue.request(token, 10 ether);
+        vm.prank(user1);
+        queue.cancel(id);
+
+        vm.prank(user1);
+        vm.expectRevert(WithdrawalQueue.InvalidStatus.selector);
+        queue.cancel(id);
+    }
+
+    function test_CancelInMiddleKeepsOrder() public {
+        vm.prank(user1);
+        uint256 id1 = queue.request(token, 10 ether);
+        vm.prank(user2);
+        uint256 id2 = queue.request(token, 20 ether);
+        vm.prank(user1);
+        uint256 id3 = queue.request(token, 30 ether);
+
+        vm.prank(user2);
+        queue.cancel(id2);
+
+        assertEq(queue.queueLength(), 2);
+
+        vm.prank(processor);
+        uint256 next = queue.processNext();
+        assertEq(next, id1);
+
+        vm.prank(processor);
+        next = queue.processNext();
+        assertEq(next, id3);
+    }
+
+    function test_CancelHeadAdvances() public {
+        vm.prank(user1);
+        uint256 id1 = queue.request(token, 10 ether);
+        vm.prank(user2);
+        uint256 id2 = queue.request(token, 20 ether);
+
+        vm.prank(user1);
+        queue.cancel(id1);
+
+        assertEq(queue.head(), id2);
+    }
+
+    // ------- queries -------
+
+    function test_GetRequestCarriesData() public {
+        vm.prank(user1);
+        uint256 id = queue.request(token, 7 ether);
+
+        WithdrawalQueue.Request memory r = queue.getRequest(id);
+        assertEq(r.user, user1);
+        assertEq(address(r.token), address(token));
+        assertEq(r.amount, 7 ether);
+        assertEq(uint8(r.status), uint8(WithdrawalQueue.Status.PENDING));
+        assertGt(uint256(r.requestedAt), 0);
+    }
+
+    function test_PendingIdsSnapshot() public {
+        vm.prank(user1);
+        queue.request(token, 1 ether);
+        vm.prank(user2);
+        queue.request(token, 2 ether);
+
+        uint256[] memory ids = queue.pendingIds();
+        assertEq(ids.length, 2);
+        assertEq(ids[0], 1);
+        assertEq(ids[1], 2);
+    }
+
+    function test_UserRequestsListAllStatuses() public {
+        vm.prank(user1);
+        uint256 id1 = queue.request(token, 1 ether);
+        vm.prank(user1);
+        uint256 id2 = queue.request(token, 2 ether);
+        vm.prank(user1);
+        queue.cancel(id1);
+
+        uint256[] memory ids = queue.userRequests(user1);
+        assertEq(ids.length, 2);
+        assertEq(ids[0], id1);
+        assertEq(ids[1], id2);
+    }
+
+    function test_HeadOnEmptyReverts() public {
+        vm.expectRevert(WithdrawalQueue.QueueEmpty.selector);
+        queue.head();
+    }
+
+    function test_StatusOfUnknownIsNone() public view {
+        assertEq(uint8(queue.statusOf(999)), uint8(WithdrawalQueue.Status.NONE));
+    }
+}


### PR DESCRIPTION
## Summary

Implements four contract-side issues from the tracker, each scoped to a single new contract plus dedicated test file. All four are independent OpenZeppelin-based modules that can be wired into the existing market/vault stack.

- **#160 — KYCStorage** (`Contracts/contracts/KYCStorage.sol`): per-user KYC record (status, level, expiry, document hash, jurisdiction). Owner manages a verifier registry; verifiers write status. Exposes paginated user listing, expiry-aware effective status, and an `isVerified(user, minLevel)` predicate.
- **#161 — MarketFreeze** (`Contracts/contracts/MarketFreeze.sol`): per-market freeze with both a market-wide `OP_ALL` switch and selective operation freezes (`OP_TRADE`, `OP_DEPOSIT`, `OP_WITHDRAW`, `OP_RESOLVE`, plus arbitrary custom ids). Owner-managed freezer registry, freeze metadata (actor, timestamp, reason), and a `requireOperationAllowed` guard for downstream contracts.
- **#162 — WithdrawalQueue** (`Contracts/contracts/WithdrawalQueue.sol`): FIFO ERC20 withdrawal queue. Users `request`/`cancel`; processors call `processNext` to settle in order. Internal swap-and-pop keeps queue ops O(1) on the hot path while preserving ordering. `ReentrancyGuard` on settlement.
- **#163 — WithdrawalLimit** (`Contracts/contracts/WithdrawalLimit.sol`): rolling-window withdrawal limits, per-token defaults plus per-user overrides, optional per-tx cap, default 24h window. Includes non-mutating `check` preview, enforcer-only `record` commit, and `remaining`/`getUsage` helpers.

## Design notes

- All four contracts use OpenZeppelin `Ownable` for admin gating; each maintains its own role list (verifiers / freezers / processors / enforcers) so day-to-day operators can be rotated without giving up ownership.
- Custom errors and sectioned NatSpec follow the conventions already used by `contracts/AccessControl.sol` and `contracts/CollateralVault.sol`.
- WithdrawalQueue is intentionally agnostic about where collateral lives: the contract itself holds the tokens to be paid out so it can be slotted in front of any vault that pre-funds it on request.
- WithdrawalLimit's window is a fixed-length non-overlapping window rather than a sliding window — much cheaper on gas and matches the operational model the issue describes ("time-based limits").

## Test plan

- [ ] `forge build`
- [ ] `forge test --match-contract KYCStorageTest`
- [ ] `forge test --match-contract MarketFreezeTest`
- [ ] `forge test --match-contract WithdrawalQueueTest`
- [ ] `forge test --match-contract WithdrawalLimitTest`

Closes #160
Closes #161
Closes #162
Closes #163