### PR TITLE
build whitelisting functionality for market access

### DIFF
--- a/Contracts/contracts/Whitelist.sol
+++ b/Contracts/contracts/Whitelist.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Whitelist
+/// @notice Manages market access whitelisting with batch updates, guards, and queryable history.
+contract Whitelist is Ownable {
+    // -------------------------------------------------------------------------
+    // Custom errors
+    // -------------------------------------------------------------------------
+    error ZeroAddress();
+    error AlreadyWhitelisted(address account);
+    error NotWhitelisted(address account);
+
+    // -------------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------------
+    struct WhitelistChange {
+        address account;
+        address operator;
+        bool whitelisted;
+        uint64 timestamp;
+    }
+
+    // -------------------------------------------------------------------------
+    // Storage
+    // -------------------------------------------------------------------------
+    mapping(address => bool) private _whitelisted;
+    mapping(address => uint256) private _whitelistedIndexPlusOne;
+    mapping(address => uint64) private _lastUpdatedAt;
+    mapping(address => address) private _lastUpdatedBy;
+
+    address[] private _whitelistedAccounts;
+    WhitelistChange[] private _changes;
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+    event Whitelisted(address indexed account, address indexed operator);
+    event Unwhitelisted(address indexed account, address indexed operator);
+    event WhitelistChanged(address indexed account, address indexed operator, bool whitelisted);
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+    modifier onlyWhitelisted(address account) {
+        if (!_whitelisted[account]) revert NotWhitelisted(account);
+        _;
+    }
+
+    modifier onlyWhitelistedCaller() {
+        if (!_whitelisted[msg.sender]) revert NotWhitelisted(msg.sender);
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Whitelist management
+    // -------------------------------------------------------------------------
+    function whitelist(address account) external onlyOwner {
+        _whitelist(account);
+    }
+
+    function unwhitelist(address account) external onlyOwner {
+        _unwhitelist(account);
+    }
+
+    function whitelistBatch(address[] calldata accounts) external onlyOwner {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            _whitelist(accounts[i]);
+        }
+    }
+
+    function unwhitelistBatch(address[] calldata accounts) external onlyOwner {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            _unwhitelist(accounts[i]);
+        }
+    }
+
+    /// @notice Alias for integrations that prefer allowlist-style naming.
+    function addToWhitelist(address account) external onlyOwner {
+        _whitelist(account);
+    }
+
+    /// @notice Alias for integrations that prefer allowlist-style naming.
+    function removeFromWhitelist(address account) external onlyOwner {
+        _unwhitelist(account);
+    }
+
+    // -------------------------------------------------------------------------
+    // Access checks
+    // -------------------------------------------------------------------------
+    function isAccessAllowed(address account) public view returns (bool) {
+        return _whitelisted[account];
+    }
+
+    function requireWhitelisted(address account) external view {
+        if (!_whitelisted[account]) revert NotWhitelisted(account);
+    }
+
+    // -------------------------------------------------------------------------
+    // Queries
+    // -------------------------------------------------------------------------
+    function isWhitelisted(address account) public view returns (bool) {
+        return _whitelisted[account];
+    }
+
+    function getWhitelistedAccounts() external view returns (address[] memory) {
+        return _whitelistedAccounts;
+    }
+
+    function getWhitelistedCount() external view returns (uint256) {
+        return _whitelistedAccounts.length;
+    }
+
+    function getWhitelistChangeCount() external view returns (uint256) {
+        return _changes.length;
+    }
+
+    function getWhitelistChange(uint256 index) external view returns (WhitelistChange memory) {
+        return _changes[index];
+    }
+
+    function listWhitelistChanges(uint256 offset, uint256 limit)
+        external
+        view
+        returns (WhitelistChange[] memory page)
+    {
+        uint256 total = _changes.length;
+        if (offset >= total || limit == 0) return new WhitelistChange[](0);
+
+        uint256 end = offset + limit;
+        if (end > total) end = total;
+
+        page = new WhitelistChange[](end - offset);
+        for (uint256 i = offset; i < end; i++) {
+            page[i - offset] = _changes[i];
+        }
+    }
+
+    function lastUpdatedAt(address account) external view returns (uint64) {
+        return _lastUpdatedAt[account];
+    }
+
+    function lastUpdatedBy(address account) external view returns (address) {
+        return _lastUpdatedBy[account];
+    }
+
+    function getWhitelistMetadata(address account)
+        external
+        view
+        returns (bool whitelisted, uint64 updatedAt, address updatedBy)
+    {
+        return (_whitelisted[account], _lastUpdatedAt[account], _lastUpdatedBy[account]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+    function _whitelist(address account) internal {
+        if (account == address(0)) revert ZeroAddress();
+        if (_whitelisted[account]) revert AlreadyWhitelisted(account);
+
+        _whitelisted[account] = true;
+        _whitelistedIndexPlusOne[account] = _whitelistedAccounts.length + 1;
+        _whitelistedAccounts.push(account);
+
+        _recordChange(account, true);
+
+        emit Whitelisted(account, msg.sender);
+        emit WhitelistChanged(account, msg.sender, true);
+    }
+
+    function _unwhitelist(address account) internal {
+        if (account == address(0)) revert ZeroAddress();
+        if (!_whitelisted[account]) revert NotWhitelisted(account);
+
+        _whitelisted[account] = false;
+        _removeWhitelistedAccount(account);
+
+        _recordChange(account, false);
+
+        emit Unwhitelisted(account, msg.sender);
+        emit WhitelistChanged(account, msg.sender, false);
+    }
+
+    function _removeWhitelistedAccount(address account) internal {
+        uint256 index = _whitelistedIndexPlusOne[account] - 1;
+        uint256 lastIndex = _whitelistedAccounts.length - 1;
+
+        if (index != lastIndex) {
+            address lastAccount = _whitelistedAccounts[lastIndex];
+            _whitelistedAccounts[index] = lastAccount;
+            _whitelistedIndexPlusOne[lastAccount] = index + 1;
+        }
+
+        _whitelistedAccounts.pop();
+        delete _whitelistedIndexPlusOne[account];
+    }
+
+    function _recordChange(address account, bool whitelisted) internal {
+        uint64 timestamp = uint64(block.timestamp);
+        _lastUpdatedAt[account] = timestamp;
+        _lastUpdatedBy[account] = msg.sender;
+        _changes.push(WhitelistChange({
+            account: account,
+            operator: msg.sender,
+            whitelisted: whitelisted,
+            timestamp: timestamp
+        }));
+    }
+}

--- a/Contracts/test/Whitelist.t.sol
+++ b/Contracts/test/Whitelist.t.sol
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/Whitelist.sol";
+
+contract WhitelistedMarketHarness is Whitelist {
+    constructor(address initialOwner) Whitelist(initialOwner) {}
+
+    function restrictedTrade() external view onlyWhitelistedCaller returns (bool) {
+        return true;
+    }
+
+    function restrictedFor(address account) external view onlyWhitelisted(account) returns (bool) {
+        return true;
+    }
+}
+
+contract WhitelistTest is Test {
+    Whitelist whitelistContract;
+    WhitelistedMarketHarness market;
+
+    address owner = address(0xA11CE);
+    address alice = address(0xBEEF);
+    address bob = address(0xCAFE);
+    address carol = address(0xD00D);
+    address other = address(0xFADE);
+
+    event Whitelisted(address indexed account, address indexed operator);
+    event Unwhitelisted(address indexed account, address indexed operator);
+    event WhitelistChanged(address indexed account, address indexed operator, bool whitelisted);
+
+    function setUp() public {
+        whitelistContract = new Whitelist(owner);
+        market = new WhitelistedMarketHarness(owner);
+    }
+
+    // ------- whitelist management -------
+
+    function test_OwnerCanWhitelistAddress() public {
+        vm.prank(owner);
+        whitelistContract.whitelist(alice);
+
+        assertTrue(whitelistContract.isWhitelisted(alice));
+        assertTrue(whitelistContract.isAccessAllowed(alice));
+        assertEq(whitelistContract.getWhitelistedCount(), 1);
+
+        address[] memory accounts = whitelistContract.getWhitelistedAccounts();
+        assertEq(accounts.length, 1);
+        assertEq(accounts[0], alice);
+    }
+
+    function test_OwnerCanUnwhitelistAddress() public {
+        vm.prank(owner);
+        whitelistContract.whitelist(alice);
+
+        vm.prank(owner);
+        whitelistContract.unwhitelist(alice);
+
+        assertFalse(whitelistContract.isWhitelisted(alice));
+        assertFalse(whitelistContract.isAccessAllowed(alice));
+        assertEq(whitelistContract.getWhitelistedCount(), 0);
+    }
+
+    function test_AddRemoveAliasesWork() public {
+        vm.prank(owner);
+        whitelistContract.addToWhitelist(alice);
+        assertTrue(whitelistContract.isWhitelisted(alice));
+
+        vm.prank(owner);
+        whitelistContract.removeFromWhitelist(alice);
+        assertFalse(whitelistContract.isWhitelisted(alice));
+    }
+
+    function test_CannotWhitelistZeroAddress() public {
+        vm.prank(owner);
+        vm.expectRevert(Whitelist.ZeroAddress.selector);
+        whitelistContract.whitelist(address(0));
+    }
+
+    function test_CannotWhitelistTwice() public {
+        vm.prank(owner);
+        whitelistContract.whitelist(alice);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Whitelist.AlreadyWhitelisted.selector, alice));
+        whitelistContract.whitelist(alice);
+    }
+
+    function test_CannotUnwhitelistUnknownAddress() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelisted.selector, alice));
+        whitelistContract.unwhitelist(alice);
+    }
+
+    function test_NonOwnerCannotWhitelist() public {
+        vm.prank(other);
+        vm.expectRevert();
+        whitelistContract.whitelist(alice);
+    }
+
+    function test_NonOwnerCannotUnwhitelist() public {
+        vm.prank(owner);
+        whitelistContract.whitelist(alice);
+
+        vm.prank(other);
+        vm.expectRevert();
+        whitelistContract.unwhitelist(alice);
+    }
+
+    // ------- batch operations -------
+
+    function test_BatchWhitelisting() public {
+        address[] memory accounts = new address[](3);
+        accounts[0] = alice;
+        accounts[1] = bob;
+        accounts[2] = carol;
+
+        vm.prank(owner);
+        whitelistContract.whitelistBatch(accounts);
+
+        assertTrue(whitelistContract.isWhitelisted(alice));
+        assertTrue(whitelistContract.isWhitelisted(bob));
+        assertTrue(whitelistContract.isWhitelisted(carol));
+        assertEq(whitelistContract.getWhitelistedCount(), 3);
+    }
+
+    function test_BatchUnwhitelisting() public {
+        address[] memory accounts = new address[](3);
+        accounts[0] = alice;
+        accounts[1] = bob;
+        accounts[2] = carol;
+
+        vm.prank(owner);
+        whitelistContract.whitelistBatch(accounts);
+
+        vm.prank(owner);
+        whitelistContract.unwhitelistBatch(accounts);
+
+        assertFalse(whitelistContract.isWhitelisted(alice));
+        assertFalse(whitelistContract.isWhitelisted(bob));
+        assertFalse(whitelistContract.isWhitelisted(carol));
+        assertEq(whitelistContract.getWhitelistedCount(), 0);
+    }
+
+    function test_BatchWhitelistRevertsOnDuplicateAndRollsBack() public {
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = alice;
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Whitelist.AlreadyWhitelisted.selector, alice));
+        whitelistContract.whitelistBatch(accounts);
+
+        assertFalse(whitelistContract.isWhitelisted(alice));
+        assertEq(whitelistContract.getWhitelistedCount(), 0);
+    }
+
+    function test_BatchUnwhitelistRevertsOnUnknownAndRollsBack() public {
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = bob;
+
+        vm.prank(owner);
+        whitelistContract.whitelist(alice);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelisted.selector, bob));
+        whitelistContract.unwhitelistBatch(accounts);
+
+        assertTrue(whitelistContract.isWhitelisted(alice));
+        assertEq(whitelistContract.getWhitelistedCount(), 1);
+    }
+
+    // ------- access control -------
+
+    function test_RequireWhitelistedControlsAccess() public {
+        vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelisted.selector, alice));
+        whitelistContract.requireWhitelisted(alice);
+
+        vm.prank(owner);
+        whitelistContract.whitelist(alice);
+
+        whitelistContract.requireWhitelisted(alice);
+    }
+
+    function test_ModifierRestrictsMarketAccessToWhitelistedCaller() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelisted.selector, alice));
+        market.restrictedTrade();
+
+        vm.prank(owner);
+        market.whitelist(alice);
+
+        vm.prank(alice);
+        assertTrue(market.restrictedTrade());
+    }
+
+    function test_ModifierCanCheckSpecificAccount() public {
+        vm.prank(owner);
+        market.whitelist(alice);
+
+        assertTrue(market.restrictedFor(alice));
+
+        vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelisted.selector, bob));
+        market.restrictedFor(bob);
+    }
+
+    // ------- tracking and queries -------
+
+    function test_WhitelistEvents() public {
+        vm.prank(owner);
+        vm.expectEmit(true, true, false, false);
+        emit Whitelisted(alice, owner);
+        vm.expectEmit(true, true, false, true);
+        emit WhitelistChanged(alice, owner, true);
+        whitelistContract.whitelist(alice);
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, false, false);
+        emit Unwhitelisted(alice, owner);
+        vm.expectEmit(true, true, false, true);
+        emit WhitelistChanged(alice, owner, false);
+        whitelistContract.unwhitelist(alice);
+    }
+
+    function test_ChangeHistoryTracksAddAndRemove() public {
+        vm.warp(1_000);
+        vm.prank(owner);
+        whitelistContract.whitelist(alice);
+
+        vm.warp(2_000);
+        vm.prank(owner);
+        whitelistContract.unwhitelist(alice);
+
+        assertEq(whitelistContract.getWhitelistChangeCount(), 2);
+
+        Whitelist.WhitelistChange memory added = whitelistContract.getWhitelistChange(0);
+        assertEq(added.account, alice);
+        assertEq(added.operator, owner);
+        assertTrue(added.whitelisted);
+        assertEq(uint256(added.timestamp), 1_000);
+
+        Whitelist.WhitelistChange memory removed = whitelistContract.getWhitelistChange(1);
+        assertEq(removed.account, alice);
+        assertEq(removed.operator, owner);
+        assertFalse(removed.whitelisted);
+        assertEq(uint256(removed.timestamp), 2_000);
+
+        (bool whitelisted, uint64 updatedAt, address updatedBy) = whitelistContract.getWhitelistMetadata(alice);
+        assertFalse(whitelisted);
+        assertEq(uint256(updatedAt), 2_000);
+        assertEq(updatedBy, owner);
+        assertEq(uint256(whitelistContract.lastUpdatedAt(alice)), 2_000);
+        assertEq(whitelistContract.lastUpdatedBy(alice), owner);
+    }
+
+    function test_ListWhitelistChangesPaginates() public {
+        address[] memory accounts = new address[](3);
+        accounts[0] = alice;
+        accounts[1] = bob;
+        accounts[2] = carol;
+
+        vm.prank(owner);
+        whitelistContract.whitelistBatch(accounts);
+
+        Whitelist.WhitelistChange[] memory page = whitelistContract.listWhitelistChanges(1, 2);
+        assertEq(page.length, 2);
+        assertEq(page[0].account, bob);
+        assertEq(page[1].account, carol);
+
+        Whitelist.WhitelistChange[] memory empty = whitelistContract.listWhitelistChanges(10, 2);
+        assertEq(empty.length, 0);
+    }
+
+    function test_GetWhitelistedAccountsReturnsOnlyActiveAddresses() public {
+        address[] memory accounts = new address[](3);
+        accounts[0] = alice;
+        accounts[1] = bob;
+        accounts[2] = carol;
+
+        vm.prank(owner);
+        whitelistContract.whitelistBatch(accounts);
+
+        vm.prank(owner);
+        whitelistContract.unwhitelist(bob);
+
+        address[] memory active = whitelistContract.getWhitelistedAccounts();
+        assertEq(active.length, 2);
+        assertTrue(active[0] == alice || active[1] == alice);
+        assertTrue(active[0] == carol || active[1] == carol);
+        assertFalse(whitelistContract.isWhitelisted(bob));
+    }
+}


### PR DESCRIPTION
Closes #158
Implemented whitelist market-access support.

Added Whitelist.sol with:

Owner-managed whitelist/unwhitelist operations
Batch add/remove
onlyWhitelisted and onlyWhitelistedCaller access guards
Query helpers for active addresses, counts, metadata, and paginated change history
Events plus on-chain WhitelistChange tracking
Added Whitelist.t.sol covering:

Address management
Access control guards
Batch operations and rollback behavior
Change tracking/events
Query and pagination behavior
Verification note: I tried to run forge test --match-contract WhitelistTest, but forge is not installed or not on PATH in this environment: zsh:1: command not found: forge. Next step is to run that command once Foundry is available.