### PR TITLE
Add time service and time utils

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -38,6 +38,7 @@
         "groq-sdk": "0.9.1",
         "ioredis": "^5.10.1",
         "mathjs": "^13.2.3",
+        "moment-timezone": "^0.6.2",
         "mongoose": "^9.5.0",
         "node-cron": "^4.2.1",
         "nodemailer": "^8.0.5",
@@ -9844,6 +9845,27 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.2.tgz",
+      "integrity": "sha512-lDsQv8FoGdBUdf0+TjGsq2orxKuXdwFlQ6Zw6TX3xIcTwTfEpCLyKqvEauvCHJ8iu3KBV8+uPhlv70YsNGdUBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mongodb": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -49,6 +49,7 @@
     "groq-sdk": "0.9.1",
     "ioredis": "^5.10.1",
     "mathjs": "^13.2.3",
+    "moment-timezone": "^0.6.2",
     "mongoose": "^9.5.0",
     "node-cron": "^4.2.1",
     "nodemailer": "^8.0.5",

--- a/Backend/services/timeService.js
+++ b/Backend/services/timeService.js
@@ -1,0 +1,72 @@
+const cron = require('node-cron');
+const timeUtils = require('../utils/timeUtils');
+
+class TimeService {
+  constructor() {
+    this.scheduledJobs = new Map();
+  }
+
+  getMarketTime(market) {
+    const timeZone = timeUtils.getMarketTimeZone(market);
+    return {
+      market,
+      timeZone,
+      currentTime: timeUtils.getCurrentTimeInZone(timeZone),
+      isDST: timeUtils.isDSTActive(timeZone)
+    };
+  }
+
+  convertMarketTime(market, date, targetTimeZone) {
+    const sourceTimeZone = timeUtils.getMarketTimeZone(market);
+    return {
+      market,
+      sourceTimeZone,
+      targetTimeZone,
+      convertedTime: timeUtils.convertTime(date, sourceTimeZone, targetTimeZone)
+    };
+  }
+
+  scheduleJob(cronExpression, jobId, callback, timeZone = 'UTC') {
+    if (this.scheduledJobs.has(jobId)) {
+      this.cancelJob(jobId);
+    }
+
+    const job = cron.schedule(cronExpression, callback, {
+      timezone: timeZone
+    });
+
+    this.scheduledJobs.set(jobId, job);
+    return { jobId, status: 'scheduled', cronExpression, timeZone };
+  }
+
+  cancelJob(jobId) {
+    const job = this.scheduledJobs.get(jobId);
+    if (job) {
+      job.stop();
+      this.scheduledJobs.delete(jobId);
+      return { jobId, status: 'cancelled' };
+    }
+    return { jobId, status: 'not_found' };
+  }
+
+  listScheduledJobs() {
+    return Array.from(this.scheduledJobs.keys()).map(jobId => ({
+      jobId
+    }));
+  }
+
+  queryTimeRange(startTime, endTime, timeZone = 'UTC') {
+    const start = timeUtils.parseTime(startTime, timeZone);
+    const end = timeUtils.parseTime(endTime, timeZone);
+    const duration = timeUtils.getTimeDifference(end, start, 'minutes');
+
+    return {
+      timeZone,
+      startTime: timeUtils.formatTime(start, 'YYYY-MM-DD HH:mm:ss', timeZone),
+      endTime: timeUtils.formatTime(end, 'YYYY-MM-DD HH:mm:ss', timeZone),
+      durationMinutes: duration
+    };
+  }
+}
+
+module.exports = new TimeService();

--- a/Backend/utils/timeUtils.js
+++ b/Backend/utils/timeUtils.js
@@ -1,0 +1,50 @@
+const moment = require('moment-timezone');
+
+const marketTimeZones = {
+  'NYSE': 'America/New_York',
+  'NASDAQ': 'America/New_York',
+  'LSE': 'Europe/London',
+  'TSE': 'Asia/Tokyo',
+  'HKEX': 'Asia/Hong_Kong',
+  'SGX': 'Asia/Singapore',
+  'ASX': 'Australia/Sydney',
+  'FSE': 'Europe/Berlin'
+};
+
+function convertTime(date, fromZone, toZone) {
+  return moment.tz(date, fromZone).tz(toZone).format();
+}
+
+function getCurrentTimeInZone(timeZone) {
+  return moment.tz(timeZone).format();
+}
+
+function isDSTActive(timeZone) {
+  return moment.tz(timeZone).isDST();
+}
+
+function getMarketTimeZone(market) {
+  return marketTimeZones[market] || 'UTC';
+}
+
+function formatTime(date, format = 'YYYY-MM-DD HH:mm:ss', timeZone = 'UTC') {
+  return moment.tz(date, timeZone).format(format);
+}
+
+function parseTime(dateString, timeZone = 'UTC') {
+  return moment.tz(dateString, timeZone).toDate();
+}
+
+function getTimeDifference(date1, date2, unit = 'minutes') {
+  return moment(date1).diff(moment(date2), unit);
+}
+
+module.exports = {
+  convertTime,
+  getCurrentTimeInZone,
+  isDSTActive,
+  getMarketTimeZone,
+  formatTime,
+  parseTime,
+  getTimeDifference
+};


### PR DESCRIPTION
Add time service and time utils

This PR adds a time service and time utilities for handling time-sensitive market operations.

Features:
- Track market time zones
- Handle daylight saving time
- Provide time conversion utilities
- Schedule time-based operations
- Support time-based queries

closes #244