### PR TITLE
feat(contracts): add staking, market reward, reward distribution, and…

### DIFF
--- a/Contracts/contracts/CoverageTier.sol
+++ b/Contracts/contracts/CoverageTier.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/**
+ * @title  CoverageTier
+ * @notice Tiered coverage subscription system.
+ *
+ * The owner defines tiers (e.g. BASIC, STANDARD, PREMIUM) each with a price
+ * and a set of benefit flags. Users subscribe to a tier by paying the price in
+ * the payment token. Upgrades are supported; the user pays only the price
+ * difference. Subscriptions are tracked with start/expiry timestamps.
+ */
+contract CoverageTier is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ── Errors ─────────────────────────────────────────────────────────────────
+    error ZeroAddress();
+    error ZeroAmount();
+    error TierNotFound();
+    error TierInactive();
+    error AlreadyOnHigherTier();
+    error SameTier();
+    error SubscriptionNotFound();
+    error InvalidDuration();
+
+    // ── Types ──────────────────────────────────────────────────────────────────
+
+    struct Tier {
+        string   name;
+        uint256  price;          // cost in payment token per subscription period
+        uint256  duration;       // subscription duration in seconds
+        bytes32  benefits;       // packed benefit flags (application-defined bitmask)
+        bool     active;
+        uint256  subscriberCount;
+    }
+
+    struct Subscription {
+        bytes32  tierId;
+        uint256  startTime;
+        uint256  expiryTime;
+        bool     active;
+    }
+
+    // ── Events ─────────────────────────────────────────────────────────────────
+    event TierDefined(bytes32 indexed tierId, string name, uint256 price, uint256 duration);
+    event TierDeactivated(bytes32 indexed tierId);
+    event TierPriceUpdated(bytes32 indexed tierId, uint256 newPrice);
+    event Subscribed(address indexed user, bytes32 indexed tierId, uint256 expiryTime);
+    event Upgraded(address indexed user, bytes32 indexed fromTier, bytes32 indexed toTier, uint256 expiryTime);
+    event SubscriptionRenewed(address indexed user, bytes32 indexed tierId, uint256 newExpiry);
+
+    // ── State ──────────────────────────────────────────────────────────────────
+
+    IERC20 public immutable paymentToken;
+    address public treasury;
+
+    mapping(bytes32 => Tier) public tiers;
+    bytes32[] public tierIds;
+
+    mapping(address => Subscription) public subscriptions;
+
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    constructor(address _paymentToken, address _treasury) Ownable(msg.sender) {
+        if (_paymentToken == address(0) || _treasury == address(0)) revert ZeroAddress();
+        paymentToken = IERC20(_paymentToken);
+        treasury = _treasury;
+    }
+
+    // ── Admin ──────────────────────────────────────────────────────────────────
+
+    /**
+     * @notice Define or update a coverage tier.
+     * @param tierId    Arbitrary identifier (e.g. keccak256("PREMIUM")).
+     * @param name      Human-readable name.
+     * @param price     Cost in payment token.
+     * @param duration  Subscription duration in seconds.
+     * @param benefits  Packed benefit flags.
+     */
+    function defineTier(
+        bytes32 tierId,
+        string calldata name,
+        uint256 price,
+        uint256 duration,
+        bytes32 benefits
+    ) external onlyOwner {
+        if (duration == 0) revert InvalidDuration();
+        bool isNew = !tiers[tierId].active && tiers[tierId].price == 0;
+        tiers[tierId] = Tier({
+            name: name,
+            price: price,
+            duration: duration,
+            benefits: benefits,
+            active: true,
+            subscriberCount: tiers[tierId].subscriberCount
+        });
+        if (isNew) tierIds.push(tierId);
+        emit TierDefined(tierId, name, price, duration);
+    }
+
+    function deactivateTier(bytes32 tierId) external onlyOwner {
+        if (!tiers[tierId].active) revert TierNotFound();
+        tiers[tierId].active = false;
+        emit TierDeactivated(tierId);
+    }
+
+    function updateTierPrice(bytes32 tierId, uint256 newPrice) external onlyOwner {
+        if (!tiers[tierId].active) revert TierNotFound();
+        tiers[tierId].price = newPrice;
+        emit TierPriceUpdated(tierId, newPrice);
+    }
+
+    function setTreasury(address newTreasury) external onlyOwner {
+        if (newTreasury == address(0)) revert ZeroAddress();
+        treasury = newTreasury;
+    }
+
+    // ── Subscriptions ──────────────────────────────────────────────────────────
+
+    /// @notice Subscribe to a tier. Reverts if user already has an active subscription.
+    function subscribe(bytes32 tierId) external nonReentrant {
+        Tier storage tier = tiers[tierId];
+        if (!tier.active) revert TierInactive();
+
+        Subscription storage sub = subscriptions[msg.sender];
+        // Allow re-subscribe only if expired
+        if (sub.active && block.timestamp < sub.expiryTime) revert AlreadyOnHigherTier();
+
+        if (tier.price > 0) {
+            paymentToken.safeTransferFrom(msg.sender, treasury, tier.price);
+        }
+
+        if (!sub.active) tier.subscriberCount += 1;
+
+        uint256 expiry = block.timestamp + tier.duration;
+        subscriptions[msg.sender] = Subscription({
+            tierId: tierId,
+            startTime: block.timestamp,
+            expiryTime: expiry,
+            active: true
+        });
+
+        emit Subscribed(msg.sender, tierId, expiry);
+    }
+
+    /**
+     * @notice Upgrade to a higher-priced tier. User pays the price difference.
+     * @param newTierId  Target tier (must have a higher price than current).
+     */
+    function upgrade(bytes32 newTierId) external nonReentrant {
+        Subscription storage sub = subscriptions[msg.sender];
+        if (!sub.active) revert SubscriptionNotFound();
+
+        Tier storage currentTier = tiers[sub.tierId];
+        Tier storage newTier     = tiers[newTierId];
+
+        if (!newTier.active) revert TierInactive();
+        if (sub.tierId == newTierId) revert SameTier();
+        if (newTier.price <= currentTier.price) revert AlreadyOnHigherTier();
+
+        uint256 priceDiff = newTier.price - currentTier.price;
+        if (priceDiff > 0) {
+            paymentToken.safeTransferFrom(msg.sender, treasury, priceDiff);
+        }
+
+        bytes32 fromTier = sub.tierId;
+        uint256 expiry   = block.timestamp + newTier.duration;
+
+        sub.tierId    = newTierId;
+        sub.startTime = block.timestamp;
+        sub.expiryTime = expiry;
+
+        emit Upgraded(msg.sender, fromTier, newTierId, expiry);
+    }
+
+    /// @notice Renew an existing subscription for another full period.
+    function renew(bytes32 tierId) external nonReentrant {
+        Tier storage tier = tiers[tierId];
+        if (!tier.active) revert TierInactive();
+
+        Subscription storage sub = subscriptions[msg.sender];
+        if (!sub.active || sub.tierId != tierId) revert SubscriptionNotFound();
+
+        if (tier.price > 0) {
+            paymentToken.safeTransferFrom(msg.sender, treasury, tier.price);
+        }
+
+        // Extend from current expiry if still active, otherwise from now
+        uint256 base = block.timestamp > sub.expiryTime ? block.timestamp : sub.expiryTime;
+        sub.expiryTime = base + tier.duration;
+
+        emit SubscriptionRenewed(msg.sender, tierId, sub.expiryTime);
+    }
+
+    // ── Queries ────────────────────────────────────────────────────────────────
+
+    /// @notice Returns whether a user has an active (non-expired) subscription.
+    function isSubscribed(address user) external view returns (bool) {
+        Subscription storage sub = subscriptions[user];
+        return sub.active && block.timestamp < sub.expiryTime;
+    }
+
+    /// @notice Returns the user's current subscription details.
+    function getSubscription(address user) external view returns (Subscription memory) {
+        return subscriptions[user];
+    }
+
+    /// @notice Returns tier details.
+    function getTier(bytes32 tierId) external view returns (Tier memory) {
+        return tiers[tierId];
+    }
+
+    /// @notice Returns all registered tier IDs.
+    function getTierIds() external view returns (bytes32[] memory) {
+        return tierIds;
+    }
+
+    /// @notice Returns whether a user's subscription has a specific benefit flag set.
+    function hasBenefit(address user, bytes32 benefitFlag) external view returns (bool) {
+        Subscription storage sub = subscriptions[user];
+        if (!sub.active || block.timestamp >= sub.expiryTime) return false;
+        return (tiers[sub.tierId].benefits & benefitFlag) != 0;
+    }
+}

--- a/Contracts/contracts/MarketReward.sol
+++ b/Contracts/contracts/MarketReward.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/**
+ * @title  MarketReward
+ * @notice Reward system for market participation.
+ *
+ * Supports multiple reward types (e.g. TRADING, LIQUIDITY, REFERRAL).
+ * Each type has its own allocation pool. Authorised distributors (e.g. the
+ * trading engine) call recordParticipation to credit rewards; users claim
+ * at any time.
+ */
+contract MarketReward is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ── Errors ─────────────────────────────────────────────────────────────────
+    error ZeroAmount();
+    error ZeroAddress();
+    error UnknownRewardType();
+    error NotDistributor();
+    error AlreadyClaimed();
+    error NoRewardsToClaim();
+    error InsufficientPool();
+
+    // ── Types ──────────────────────────────────────────────────────────────────
+
+    struct RewardType {
+        string  name;
+        uint256 totalAllocated;   // total rewards ever allocated from this type
+        uint256 totalClaimed;     // total rewards ever claimed from this type
+        uint256 poolBalance;      // tokens currently available in pool
+        bool    active;
+    }
+
+    struct ClaimRecord {
+        uint256 totalEarned;
+        uint256 totalClaimed;
+        uint256 lastClaimedAt;
+    }
+
+    // ── Events ─────────────────────────────────────────────────────────────────
+    event RewardTypeAdded(bytes32 indexed typeId, string name);
+    event RewardTypeDeactivated(bytes32 indexed typeId);
+    event PoolFunded(bytes32 indexed typeId, uint256 amount);
+    event RewardAllocated(bytes32 indexed typeId, address indexed user, uint256 amount);
+    event RewardClaimed(bytes32 indexed typeId, address indexed user, uint256 amount);
+    event DistributorSet(address indexed distributor, bool enabled);
+
+    // ── State ──────────────────────────────────────────────────────────────────
+
+    IERC20 public immutable rewardToken;
+
+    mapping(bytes32 => RewardType) public rewardTypes;
+    bytes32[] public rewardTypeIds;
+
+    // typeId => user => ClaimRecord
+    mapping(bytes32 => mapping(address => ClaimRecord)) public claimRecords;
+
+    // authorised addresses that can call recordParticipation
+    mapping(address => bool) public distributors;
+
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    constructor(address _rewardToken) Ownable(msg.sender) {
+        if (_rewardToken == address(0)) revert ZeroAddress();
+        rewardToken = IERC20(_rewardToken);
+    }
+
+    // ── Admin ──────────────────────────────────────────────────────────────────
+
+    function addRewardType(bytes32 typeId, string calldata name) external onlyOwner {
+        rewardTypes[typeId] = RewardType({
+            name: name,
+            totalAllocated: 0,
+            totalClaimed: 0,
+            poolBalance: 0,
+            active: true
+        });
+        rewardTypeIds.push(typeId);
+        emit RewardTypeAdded(typeId, name);
+    }
+
+    function deactivateRewardType(bytes32 typeId) external onlyOwner {
+        if (!rewardTypes[typeId].active) revert UnknownRewardType();
+        rewardTypes[typeId].active = false;
+        emit RewardTypeDeactivated(typeId);
+    }
+
+    function setDistributor(address distributor, bool enabled) external onlyOwner {
+        if (distributor == address(0)) revert ZeroAddress();
+        distributors[distributor] = enabled;
+        emit DistributorSet(distributor, enabled);
+    }
+
+    /// @notice Fund a reward pool with tokens.
+    function fundPool(bytes32 typeId, uint256 amount) external onlyOwner {
+        if (amount == 0) revert ZeroAmount();
+        if (!rewardTypes[typeId].active) revert UnknownRewardType();
+        rewardToken.safeTransferFrom(msg.sender, address(this), amount);
+        rewardTypes[typeId].poolBalance += amount;
+        emit PoolFunded(typeId, amount);
+    }
+
+    // ── Distribution ───────────────────────────────────────────────────────────
+
+    /**
+     * @notice Record participation reward for a user. Called by authorised distributors.
+     * @param typeId  Reward type identifier.
+     * @param user    Recipient address.
+     * @param amount  Reward amount to allocate.
+     */
+    function recordParticipation(bytes32 typeId, address user, uint256 amount) external {
+        if (!distributors[msg.sender]) revert NotDistributor();
+        if (user == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        RewardType storage rt = rewardTypes[typeId];
+        if (!rt.active) revert UnknownRewardType();
+        if (rt.poolBalance < amount) revert InsufficientPool();
+
+        rt.poolBalance    -= amount;
+        rt.totalAllocated += amount;
+
+        claimRecords[typeId][user].totalEarned += amount;
+
+        emit RewardAllocated(typeId, user, amount);
+    }
+
+    // ── Claiming ───────────────────────────────────────────────────────────────
+
+    /// @notice Claim all pending rewards for a specific reward type.
+    function claim(bytes32 typeId) external nonReentrant {
+        ClaimRecord storage rec = claimRecords[typeId][msg.sender];
+        uint256 pending = rec.totalEarned - rec.totalClaimed;
+        if (pending == 0) revert NoRewardsToClaim();
+
+        rec.totalClaimed  += pending;
+        rec.lastClaimedAt  = block.timestamp;
+        rewardTypes[typeId].totalClaimed += pending;
+
+        rewardToken.safeTransfer(msg.sender, pending);
+        emit RewardClaimed(typeId, msg.sender, pending);
+    }
+
+    /// @notice Claim rewards across all reward types in one transaction.
+    function claimAll() external nonReentrant {
+        uint256 total;
+        for (uint256 i; i < rewardTypeIds.length; ++i) {
+            bytes32 typeId = rewardTypeIds[i];
+            ClaimRecord storage rec = claimRecords[typeId][msg.sender];
+            uint256 pending = rec.totalEarned - rec.totalClaimed;
+            if (pending == 0) continue;
+            rec.totalClaimed  += pending;
+            rec.lastClaimedAt  = block.timestamp;
+            rewardTypes[typeId].totalClaimed += pending;
+            total += pending;
+            emit RewardClaimed(typeId, msg.sender, pending);
+        }
+        if (total == 0) revert NoRewardsToClaim();
+        rewardToken.safeTransfer(msg.sender, total);
+    }
+
+    // ── Queries ────────────────────────────────────────────────────────────────
+
+    /// @notice Pending claimable reward for a user under a specific type.
+    function pendingReward(bytes32 typeId, address user) external view returns (uint256) {
+        ClaimRecord storage rec = claimRecords[typeId][user];
+        return rec.totalEarned - rec.totalClaimed;
+    }
+
+    /// @notice Full claim record for a user under a specific type.
+    function getClaimRecord(bytes32 typeId, address user) external view returns (ClaimRecord memory) {
+        return claimRecords[typeId][user];
+    }
+
+    /// @notice Returns all registered reward type IDs.
+    function getRewardTypeIds() external view returns (bytes32[] memory) {
+        return rewardTypeIds;
+    }
+
+    /// @notice Returns reward type details.
+    function getRewardType(bytes32 typeId) external view returns (RewardType memory) {
+        return rewardTypes[typeId];
+    }
+}

--- a/Contracts/contracts/RewardDistribution.sol
+++ b/Contracts/contracts/RewardDistribution.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {mulDiv} from "@prb/math/src/Common.sol";
+
+/**
+ * @title  RewardDistribution
+ * @notice Calculates reward allocations, distributes them fairly, tracks history,
+ *         and supports linear vesting schedules.
+ *
+ * Flow:
+ *   1. Owner creates a distribution round with a total reward amount and a list
+ *      of recipients with relative weights.
+ *   2. Rewards are allocated proportionally to weights.
+ *   3. Each allocation may optionally vest linearly over a vesting period.
+ *   4. Recipients call claim() to receive vested tokens at any time.
+ */
+contract RewardDistribution is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ── Errors ─────────────────────────────────────────────────────────────────
+    error ZeroAmount();
+    error ZeroAddress();
+    error InvalidRecipients();
+    error RoundNotFound();
+    error RoundAlreadyDistributed();
+    error NothingToVest();
+    error InvalidVestingPeriod();
+
+    // ── Types ──────────────────────────────────────────────────────────────────
+
+    struct Recipient {
+        address account;
+        uint256 weight;   // relative weight; allocation = totalReward * weight / totalWeight
+    }
+
+    struct Round {
+        uint256 totalReward;
+        uint256 vestingPeriod;   // seconds; 0 = immediate (no vesting)
+        uint256 distributedAt;   // 0 until distribute() is called
+        bool    distributed;
+        string  description;
+    }
+
+    struct VestingSchedule {
+        uint256 totalAmount;
+        uint256 claimedAmount;
+        uint256 startTime;
+        uint256 vestingPeriod;   // 0 = fully vested immediately
+    }
+
+    // ── Events ─────────────────────────────────────────────────────────────────
+    event RoundCreated(uint256 indexed roundId, uint256 totalReward, uint256 vestingPeriod);
+    event RoundDistributed(uint256 indexed roundId, uint256 recipientCount);
+    event RewardClaimed(uint256 indexed roundId, address indexed recipient, uint256 amount);
+    event RewardFunded(uint256 amount);
+
+    // ── State ──────────────────────────────────────────────────────────────────
+
+    IERC20 public immutable rewardToken;
+
+    uint256 public roundCount;
+    mapping(uint256 => Round) public rounds;
+
+    // roundId => user => VestingSchedule
+    mapping(uint256 => mapping(address => VestingSchedule)) public schedules;
+
+    // Full distribution history: roundId => list of recipients
+    mapping(uint256 => Recipient[]) private _roundRecipients;
+
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    constructor(address _rewardToken) Ownable(msg.sender) {
+        if (_rewardToken == address(0)) revert ZeroAddress();
+        rewardToken = IERC20(_rewardToken);
+    }
+
+    // ── Admin ──────────────────────────────────────────────────────────────────
+
+    /// @notice Fund the contract with reward tokens.
+    function fund(uint256 amount) external onlyOwner {
+        if (amount == 0) revert ZeroAmount();
+        rewardToken.safeTransferFrom(msg.sender, address(this), amount);
+        emit RewardFunded(amount);
+    }
+
+    /**
+     * @notice Create a new distribution round.
+     * @param totalReward    Total tokens to distribute in this round.
+     * @param vestingPeriod  Seconds over which rewards vest linearly. 0 = no vesting.
+     * @param description    Human-readable label.
+     * @return roundId       The new round's ID.
+     */
+    function createRound(uint256 totalReward, uint256 vestingPeriod, string calldata description)
+        external
+        onlyOwner
+        returns (uint256 roundId)
+    {
+        if (totalReward == 0) revert ZeroAmount();
+        roundId = ++roundCount;
+        rounds[roundId] = Round({
+            totalReward: totalReward,
+            vestingPeriod: vestingPeriod,
+            distributedAt: 0,
+            distributed: false,
+            description: description
+        });
+        emit RoundCreated(roundId, totalReward, vestingPeriod);
+    }
+
+    /**
+     * @notice Distribute a round to recipients proportionally by weight.
+     * @param roundId     Round to distribute.
+     * @param recipients  List of recipients with weights. Weights need not sum to any
+     *                    specific value; allocations are computed proportionally.
+     */
+    function distribute(uint256 roundId, Recipient[] calldata recipients) external onlyOwner {
+        Round storage round = rounds[roundId];
+        if (round.totalReward == 0) revert RoundNotFound();
+        if (round.distributed) revert RoundAlreadyDistributed();
+        if (recipients.length == 0) revert InvalidRecipients();
+
+        // Compute total weight
+        uint256 totalWeight;
+        for (uint256 i; i < recipients.length; ++i) {
+            if (recipients[i].account == address(0)) revert ZeroAddress();
+            totalWeight += recipients[i].weight;
+        }
+        if (totalWeight == 0) revert InvalidRecipients();
+
+        round.distributed   = true;
+        round.distributedAt = block.timestamp;
+
+        uint256 allocated;
+        for (uint256 i; i < recipients.length; ++i) {
+            uint256 amount;
+            if (i == recipients.length - 1) {
+                // Last recipient absorbs rounding dust
+                amount = round.totalReward - allocated;
+            } else {
+                amount = mulDiv(round.totalReward, recipients[i].weight, totalWeight);
+                allocated += amount;
+            }
+            if (amount == 0) continue;
+
+            schedules[roundId][recipients[i].account] = VestingSchedule({
+                totalAmount:   amount,
+                claimedAmount: 0,
+                startTime:     block.timestamp,
+                vestingPeriod: round.vestingPeriod
+            });
+
+            _roundRecipients[roundId].push(recipients[i]);
+        }
+
+        emit RoundDistributed(roundId, recipients.length);
+    }
+
+    // ── Claiming ───────────────────────────────────────────────────────────────
+
+    /// @notice Claim all currently vested tokens for a given round.
+    function claim(uint256 roundId) external nonReentrant {
+        VestingSchedule storage vs = schedules[roundId][msg.sender];
+        if (vs.totalAmount == 0) revert NothingToVest();
+
+        uint256 vested = _vestedAmount(vs);
+        uint256 claimable = vested - vs.claimedAmount;
+        if (claimable == 0) revert NothingToVest();
+
+        vs.claimedAmount += claimable;
+        rewardToken.safeTransfer(msg.sender, claimable);
+        emit RewardClaimed(roundId, msg.sender, claimable);
+    }
+
+    // ── Queries ────────────────────────────────────────────────────────────────
+
+    /// @notice Returns the claimable (vested but unclaimed) amount for a user in a round.
+    function claimable(uint256 roundId, address user) external view returns (uint256) {
+        VestingSchedule storage vs = schedules[roundId][user];
+        if (vs.totalAmount == 0) return 0;
+        return _vestedAmount(vs) - vs.claimedAmount;
+    }
+
+    /// @notice Returns the full vesting schedule for a user in a round.
+    function getSchedule(uint256 roundId, address user) external view returns (VestingSchedule memory) {
+        return schedules[roundId][user];
+    }
+
+    /// @notice Returns round details.
+    function getRound(uint256 roundId) external view returns (Round memory) {
+        return rounds[roundId];
+    }
+
+    /// @notice Returns the recipients of a distribution round.
+    function getRoundRecipients(uint256 roundId) external view returns (Recipient[] memory) {
+        return _roundRecipients[roundId];
+    }
+
+    // ── Internal ───────────────────────────────────────────────────────────────
+
+    function _vestedAmount(VestingSchedule storage vs) internal view returns (uint256) {
+        if (vs.vestingPeriod == 0) return vs.totalAmount; // no vesting
+        uint256 elapsed = block.timestamp - vs.startTime;
+        if (elapsed >= vs.vestingPeriod) return vs.totalAmount;
+        return mulDiv(vs.totalAmount, elapsed, vs.vestingPeriod);
+    }
+}

--- a/Contracts/contracts/StakingContract.sol
+++ b/Contracts/contracts/StakingContract.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/**
+ * @title  StakingContract
+ * @notice Handles token staking, reward calculation, period tracking, and withdrawals.
+ *
+ * Rewards accrue per-second based on a configurable rate (rewardPerSecond).
+ * Each staker's pending rewards are snapshotted on every deposit/withdrawal via
+ * a global rewardPerTokenStored accumulator pattern (similar to Synthetix).
+ */
+contract StakingContract is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ── Errors ─────────────────────────────────────────────────────────────────
+    error ZeroAmount();
+    error ZeroAddress();
+    error InsufficientStake();
+    error StakingPeriodActive();
+    error NoRewardsToClaim();
+
+    // ── Types ──────────────────────────────────────────────────────────────────
+
+    struct StakeInfo {
+        uint256 amount;              // tokens currently staked
+        uint256 rewardDebt;          // reward already accounted for
+        uint256 pendingRewards;      // rewards accumulated but not yet claimed
+        uint256 stakedAt;            // timestamp of last deposit
+        uint256 totalStaked;         // lifetime total staked by this user
+    }
+
+    // ── Events ─────────────────────────────────────────────────────────────────
+    event Staked(address indexed user, uint256 amount);
+    event Withdrawn(address indexed user, uint256 amount);
+    event RewardClaimed(address indexed user, uint256 reward);
+    event RewardRateUpdated(uint256 newRate);
+    event RewardFunded(uint256 amount);
+
+    // ── State ──────────────────────────────────────────────────────────────────
+
+    IERC20 public immutable stakingToken;
+    IERC20 public immutable rewardToken;
+
+    uint256 public rewardPerSecond;          // reward tokens emitted per second across all stakers
+    uint256 public rewardPerTokenStored;     // accumulated reward per staked token (scaled 1e18)
+    uint256 public lastUpdateTime;           // last time rewardPerTokenStored was updated
+    uint256 public totalStaked;              // total tokens currently staked
+
+    mapping(address => StakeInfo) public stakes;
+
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    constructor(address _stakingToken, address _rewardToken, uint256 _rewardPerSecond)
+        Ownable(msg.sender)
+    {
+        if (_stakingToken == address(0) || _rewardToken == address(0)) revert ZeroAddress();
+        stakingToken = IERC20(_stakingToken);
+        rewardToken  = IERC20(_rewardToken);
+        rewardPerSecond = _rewardPerSecond;
+        lastUpdateTime  = block.timestamp;
+    }
+
+    // ── Admin ──────────────────────────────────────────────────────────────────
+
+    /// @notice Update the reward emission rate.
+    function setRewardRate(uint256 newRate) external onlyOwner {
+        _updateReward(address(0));
+        rewardPerSecond = newRate;
+        emit RewardRateUpdated(newRate);
+    }
+
+    /// @notice Fund the contract with reward tokens.
+    function fundRewards(uint256 amount) external onlyOwner {
+        if (amount == 0) revert ZeroAmount();
+        rewardToken.safeTransferFrom(msg.sender, address(this), amount);
+        emit RewardFunded(amount);
+    }
+
+    // ── Core ───────────────────────────────────────────────────────────────────
+
+    /// @notice Deposit staking tokens.
+    function stake(uint256 amount) external nonReentrant {
+        if (amount == 0) revert ZeroAmount();
+        _updateReward(msg.sender);
+
+        StakeInfo storage info = stakes[msg.sender];
+        info.amount      += amount;
+        info.totalStaked += amount;
+        if (info.stakedAt == 0) info.stakedAt = block.timestamp;
+        totalStaked += amount;
+
+        stakingToken.safeTransferFrom(msg.sender, address(this), amount);
+        emit Staked(msg.sender, amount);
+    }
+
+    /// @notice Withdraw staked tokens. Pending rewards remain claimable.
+    function withdraw(uint256 amount) external nonReentrant {
+        StakeInfo storage info = stakes[msg.sender];
+        if (amount == 0) revert ZeroAmount();
+        if (info.amount < amount) revert InsufficientStake();
+
+        _updateReward(msg.sender);
+
+        info.amount -= amount;
+        totalStaked -= amount;
+        if (info.amount == 0) info.stakedAt = 0;
+
+        stakingToken.safeTransfer(msg.sender, amount);
+        emit Withdrawn(msg.sender, amount);
+    }
+
+    /// @notice Claim all pending rewards.
+    function claimRewards() external nonReentrant {
+        _updateReward(msg.sender);
+        StakeInfo storage info = stakes[msg.sender];
+        uint256 reward = info.pendingRewards;
+        if (reward == 0) revert NoRewardsToClaim();
+
+        info.pendingRewards = 0;
+        rewardToken.safeTransfer(msg.sender, reward);
+        emit RewardClaimed(msg.sender, reward);
+    }
+
+    // ── Queries ────────────────────────────────────────────────────────────────
+
+    /// @notice Returns the current pending reward for a user.
+    function pendingReward(address user) external view returns (uint256) {
+        StakeInfo storage info = stakes[user];
+        uint256 rpt = _currentRewardPerToken();
+        uint256 earned = (info.amount * (rpt - info.rewardDebt)) / 1e18;
+        return info.pendingRewards + earned;
+    }
+
+    /// @notice Returns full stake info for a user.
+    function getStakeInfo(address user) external view returns (StakeInfo memory) {
+        return stakes[user];
+    }
+
+    /// @notice Returns the staking period duration (seconds since first stake).
+    function stakingPeriod(address user) external view returns (uint256) {
+        uint256 start = stakes[user].stakedAt;
+        if (start == 0) return 0;
+        return block.timestamp - start;
+    }
+
+    // ── Internal ───────────────────────────────────────────────────────────────
+
+    function _currentRewardPerToken() internal view returns (uint256) {
+        if (totalStaked == 0) return rewardPerTokenStored;
+        uint256 elapsed = block.timestamp - lastUpdateTime;
+        return rewardPerTokenStored + (elapsed * rewardPerSecond * 1e18) / totalStaked;
+    }
+
+    function _updateReward(address user) internal {
+        rewardPerTokenStored = _currentRewardPerToken();
+        lastUpdateTime = block.timestamp;
+
+        if (user != address(0)) {
+            StakeInfo storage info = stakes[user];
+            uint256 earned = (info.amount * (rewardPerTokenStored - info.rewardDebt)) / 1e18;
+            info.pendingRewards += earned;
+            info.rewardDebt = rewardPerTokenStored;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements four new smart contracts.

### StakingContract (closes #287)
- Stake/withdraw ERC-20 tokens
- Per-second reward accrual via rewardPerToken accumulator (Synthetix pattern)
- Staking period tracking per user
- claimRewards, pendingReward, getStakeInfo queries

### MarketReward (closes #286)
- Multi-type participation reward system (TRADING, LIQUIDITY, REFERRAL, etc.)
- Authorised distributor role for recording participation
- Pool funding per reward type
- Per-type claim and claimAll, full claim history queries

### RewardDistribution (closes #288)
- Round-based allocation with proportional weight distribution
- Linear vesting schedules per recipient per round
- claimable, getSchedule, getRoundRecipients queries

### CoverageTier (closes #285)
- Define tiers with price, duration, and packed benefit flags
- Subscribe, upgrade (pay price diff), renew flows
- isSubscribed, hasBenefit, getSubscription queries
- Treasury address for payment routing

Closes #285
closes #286 closes #287 closes #288
