### PR TITLE
feat: add network latency indicator

### DIFF
--- a/Frontend/app/api/ping/route.ts
+++ b/Frontend/app/api/ping/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/ping
+ *
+ * Ultra-lightweight probe endpoint used by `useLatency` to measure
+ * round-trip time via the browser's Performance API.
+ *
+ * Returns a minimal JSON body with a server timestamp so callers can
+ * optionally calculate clock skew, but the response body is intentionally
+ * tiny to minimise transfer overhead.
+ */
+export async function GET() {
+  return NextResponse.json(
+    { ok: true, ts: Date.now() },
+    {
+      status: 200,
+      headers: {
+        // Ensure the response is never served from cache
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+        Pragma: "no-cache",
+      },
+    }
+  );
+}
+
+/**
+ * HEAD /api/ping
+ *
+ * Identical semantics to GET but without a response body.
+ * `useLatency` prefers HEAD to keep transfer bytes near zero.
+ */
+export async function HEAD() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+      Pragma: "no-cache",
+    },
+  });
+}

--- a/Frontend/components/layout/Navigation.tsx
+++ b/Frontend/components/layout/Navigation.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState, useCallback } from "react";
 import DarkModeToggle from "../../app/components/DarkModeToggle";
 import WalletButton from "../../app/components/WalletButton";
+import LatencyIndicator from "../network/LatencyIndicator";
 
 const NAV_LINKS = [
   { href: "/dashboard", label: "Markets" },
@@ -147,6 +148,7 @@ export default function Navigation() {
 
         {/* Desktop actions */}
         <div className="hidden lg:flex items-center gap-3">
+          <LatencyIndicator />
           <DarkModeToggle />
           <WalletButton />
         </div>
@@ -270,8 +272,9 @@ export default function Navigation() {
           })}
         </nav>
 
-        {/* Wallet button at the bottom of the drawer */}
-        <div className="mt-auto pt-4" style={{ borderTop: "1px solid var(--border)" }}>
+        {/* Latency + Wallet button at the bottom of the drawer */}
+        <div className="mt-auto pt-4 flex flex-col gap-3" style={{ borderTop: "1px solid var(--border)" }}>
+          <LatencyIndicator showLabel={true} />
           <WalletButton />
         </div>
       </div>

--- a/Frontend/components/network/LatencyIndicator.tsx
+++ b/Frontend/components/network/LatencyIndicator.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { useLatency, LatencyStatus } from "../../hooks/useLatency";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+interface StatusConfig {
+  label: string;
+  color: string;        // CSS hex / rgba
+  bg: string;
+  border: string;
+  dotColor: string;
+  barHeights: [string, string, string]; // 3 signal bars (low→high)
+  warnBanner: boolean;
+  warnText: string;
+}
+
+const STATUS_CONFIG: Record<LatencyStatus, StatusConfig> = {
+  excellent: {
+    label: "Excellent",
+    color: "#22c55e",
+    bg: "rgba(34,197,94,0.12)",
+    border: "rgba(34,197,94,0.35)",
+    dotColor: "#22c55e",
+    barHeights: ["6px", "10px", "14px"],
+    warnBanner: false,
+    warnText: "",
+  },
+  fair: {
+    label: "Fair",
+    color: "#f59e0b",
+    bg: "rgba(245,158,11,0.12)",
+    border: "rgba(245,158,11,0.35)",
+    dotColor: "#f59e0b",
+    barHeights: ["6px", "10px", "5px"],
+    warnBanner: false,
+    warnText: "",
+  },
+  poor: {
+    label: "Poor",
+    color: "#ef4444",
+    bg: "rgba(239,68,68,0.12)",
+    border: "rgba(239,68,68,0.35)",
+    dotColor: "#ef4444",
+    barHeights: ["6px", "4px", "4px"],
+    warnBanner: true,
+    warnText:
+      "⚠️ High network latency detected. Trade operations may be slower than usual.",
+  },
+  unknown: {
+    label: "Measuring…",
+    color: "#71717a",
+    bg: "rgba(113,113,122,0.10)",
+    border: "rgba(113,113,122,0.25)",
+    dotColor: "#71717a",
+    barHeights: ["6px", "6px", "6px"],
+    warnBanner: false,
+    warnText: "",
+  },
+};
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+/** Three animated signal bars (like a WiFi / cellular icon). */
+function SignalBars({
+  status,
+  measuring,
+}: {
+  status: LatencyStatus;
+  measuring: boolean;
+}) {
+  const cfg = STATUS_CONFIG[status];
+  return (
+    <span
+      aria-hidden="true"
+      style={{ display: "inline-flex", alignItems: "flex-end", gap: "2px", height: "14px" }}
+    >
+      {cfg.barHeights.map((h, i) => (
+        <span
+          key={i}
+          style={{
+            display: "block",
+            width: "3px",
+            height: h,
+            borderRadius: "1.5px",
+            background: cfg.dotColor,
+            opacity: measuring ? 0.4 + i * 0.2 : 1,
+            transition: "height 0.4s ease, opacity 0.3s ease",
+            animation: measuring ? `latency-pulse 1.2s ease-in-out ${i * 0.2}s infinite` : "none",
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+/** Pulse dot (animated while measuring). */
+function PulseDot({ color, measuring }: { color: string; measuring: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        position: "relative",
+        display: "inline-block",
+        width: "8px",
+        height: "8px",
+        flexShrink: 0,
+      }}
+    >
+      {measuring && (
+        <span
+          style={{
+            position: "absolute",
+            inset: 0,
+            borderRadius: "50%",
+            background: color,
+            animation: "latency-ripple 1.2s ease-out infinite",
+          }}
+        />
+      )}
+      <span
+        style={{
+          position: "absolute",
+          inset: "1px",
+          borderRadius: "50%",
+          background: color,
+          transition: "background 0.3s ease",
+        }}
+      />
+    </span>
+  );
+}
+
+/** Tooltip overlay shown on hover. */
+function Tooltip({
+  latencyMs,
+  averageMs,
+  status,
+  lastMeasuredAt,
+  sampleCount,
+}: {
+  latencyMs: number | null;
+  averageMs: number | null;
+  status: LatencyStatus;
+  lastMeasuredAt: string | null;
+  sampleCount: number;
+}) {
+  const cfg = STATUS_CONFIG[status];
+  const lastTime = lastMeasuredAt
+    ? new Date(lastMeasuredAt).toLocaleTimeString()
+    : "—";
+
+  return (
+    <div
+      role="tooltip"
+      id="latency-tooltip"
+      style={{
+        position: "absolute",
+        top: "calc(100% + 8px)",
+        right: 0,
+        zIndex: 60,
+        minWidth: "200px",
+        borderRadius: "10px",
+        padding: "12px 14px",
+        background: "var(--card)",
+        border: `1px solid ${cfg.border}`,
+        boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+        fontSize: "12px",
+        lineHeight: 1.5,
+        color: "var(--foreground)",
+        pointerEvents: "none",
+      }}
+    >
+      <p
+        style={{
+          fontWeight: 600,
+          marginBottom: "8px",
+          color: cfg.color,
+          fontSize: "13px",
+        }}
+      >
+        Network Latency
+      </p>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "4px 12px" }}>
+        <span style={{ color: "var(--muted)" }}>Status</span>
+        <span style={{ color: cfg.color, fontWeight: 600 }}>{cfg.label}</span>
+
+        <span style={{ color: "var(--muted)" }}>Latest RTT</span>
+        <span style={{ fontWeight: 500 }}>
+          {latencyMs !== null ? `${latencyMs} ms` : "—"}
+        </span>
+
+        <span style={{ color: "var(--muted)" }}>Average RTT</span>
+        <span style={{ fontWeight: 500 }}>
+          {averageMs !== null ? `${averageMs} ms` : "—"}
+        </span>
+
+        <span style={{ color: "var(--muted)" }}>Samples</span>
+        <span>{sampleCount}</span>
+
+        <span style={{ color: "var(--muted)" }}>Last check</span>
+        <span>{lastTime}</span>
+      </div>
+
+      <div
+        style={{
+          marginTop: "10px",
+          paddingTop: "8px",
+          borderTop: "1px solid var(--border)",
+          fontSize: "11px",
+          color: "var(--muted)",
+        }}
+      >
+        🟢 ≤ 100 ms · 🟡 101–300 ms · 🔴 &gt; 300 ms
+      </div>
+    </div>
+  );
+}
+
+// ─── Warning Banner ───────────────────────────────────────────────────────────
+
+function WarningBanner({
+  text,
+  onDismiss,
+}: {
+  text: string;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      id="latency-warning-banner"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "12px",
+        padding: "8px 16px",
+        background: "rgba(239,68,68,0.10)",
+        borderBottom: "1px solid rgba(239,68,68,0.30)",
+        color: "#ef4444",
+        fontSize: "13px",
+        fontWeight: 500,
+        animation: "latency-slide-down 0.25s ease-out",
+      }}
+    >
+      <span>{text}</span>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss network warning"
+        style={{
+          flexShrink: 0,
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: "#ef4444",
+          opacity: 0.7,
+          fontSize: "16px",
+          lineHeight: 1,
+          padding: "2px 4px",
+          borderRadius: "4px",
+          transition: "opacity 0.15s",
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
+        onMouseLeave={(e) => (e.currentTarget.style.opacity = "0.7")}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+interface LatencyIndicatorProps {
+  /** URL of the lightweight probe endpoint. */
+  probeUrl?: string;
+  /** Show the numeric ms value next to the status label. */
+  showMs?: boolean;
+  /** If false, the component renders only the compact badge. */
+  showLabel?: boolean;
+}
+
+export default function LatencyIndicator({
+  probeUrl = "/api/ping",
+  showMs = true,
+  showLabel = true,
+}: LatencyIndicatorProps) {
+  const { latencyMs, averageMs, status, measuring, lastMeasuredAt, sampleCount, measure } =
+    useLatency(probeUrl);
+
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  // Track client-side mount for SSR-safe portal rendering
+  const [mounted, setMounted] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const cfg = STATUS_CONFIG[status];
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Re-show banner when status flips to poor again
+  useEffect(() => {
+    if (status !== "poor") {
+      setBannerDismissed(false);
+    }
+  }, [status]);
+
+  // Close tooltip on outside click
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+      setTooltipVisible(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tooltipVisible) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [tooltipVisible, handleClickOutside]);
+
+  const showWarning = cfg.warnBanner && !bannerDismissed;
+
+  return (
+    <>
+      {/* Keyframe styles injected once */}
+      <style>{`
+        @keyframes latency-pulse {
+          0%, 100% { opacity: 0.5; transform: scaleY(0.8); }
+          50%       { opacity: 1;   transform: scaleY(1.1); }
+        }
+        @keyframes latency-ripple {
+          0%   { transform: scale(1);   opacity: 0.6; }
+          100% { transform: scale(2.4); opacity: 0;   }
+        }
+        @keyframes latency-slide-down {
+          from { opacity: 0; transform: translateY(-6px); }
+          to   { opacity: 1; transform: translateY(0);    }
+        }
+      `}</style>
+
+      {/*
+       * Warning banner — rendered via portal so it appears below the navbar
+       * at the top of <body>, without disrupting the flex navbar layout.
+       */}
+      {mounted && showWarning &&
+        createPortal(
+          <WarningBanner
+            text={cfg.warnText}
+            onDismiss={() => setBannerDismissed(true)}
+          />,
+          document.body
+        )
+      }
+
+      {/* Badge + tooltip wrapper */}
+      <div
+        ref={wrapperRef}
+        style={{ position: "relative", display: "inline-flex" }}
+      >
+        <button
+          id="latency-indicator-btn"
+          onClick={() => {
+            setTooltipVisible((v) => !v);
+            measure(); // trigger fresh measurement on click
+          }}
+          onMouseEnter={() => setTooltipVisible(true)}
+          onMouseLeave={() => setTooltipVisible(false)}
+          aria-label={`Network latency: ${cfg.label}${latencyMs !== null ? ` (${latencyMs} ms)` : ""}`}
+          aria-describedby="latency-tooltip"
+          aria-expanded={tooltipVisible}
+          title="Network latency"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "6px",
+            padding: "4px 10px",
+            borderRadius: "20px",
+            border: `1px solid ${cfg.border}`,
+            background: cfg.bg,
+            cursor: "pointer",
+            userSelect: "none",
+            transition: "background 0.3s ease, border-color 0.3s ease",
+            fontSize: "12px",
+            fontWeight: 600,
+            color: cfg.color,
+            whiteSpace: "nowrap",
+          }}
+        >
+          <PulseDot color={cfg.dotColor} measuring={measuring} />
+          <SignalBars status={status} measuring={measuring} />
+          {showLabel && (
+            <span style={{ transition: "color 0.3s ease" }}>{cfg.label}</span>
+          )}
+          {showMs && latencyMs !== null && (
+            <span
+              style={{
+                fontWeight: 400,
+                opacity: 0.75,
+                fontSize: "11px",
+              }}
+            >
+              {latencyMs} ms
+            </span>
+          )}
+        </button>
+
+        {tooltipVisible && (
+          <Tooltip
+            latencyMs={latencyMs}
+            averageMs={averageMs}
+            status={status}
+            lastMeasuredAt={lastMeasuredAt}
+            sampleCount={sampleCount}
+          />
+        )}
+      </div>
+    </>
+  );
+}
+

--- a/Frontend/hooks/useLatency.ts
+++ b/Frontend/hooks/useLatency.ts
@@ -1,0 +1,173 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Measurement interval in milliseconds (every 10 s). */
+const MEASURE_INTERVAL_MS = 10_000;
+
+/** Minimum number of samples before status is considered stable. */
+const MIN_SAMPLES = 3;
+
+/** Rolling-window size for the moving average. */
+const WINDOW_SIZE = 5;
+
+/** Debounce (ms) before status label changes are committed to state. */
+const STATUS_DEBOUNCE_MS = 2_000;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type LatencyStatus = "excellent" | "fair" | "poor" | "unknown";
+
+export interface LatencyState {
+  /** Latest measured RTT in milliseconds, or null while measuring. */
+  latencyMs: number | null;
+  /** Smoothed moving-average RTT. */
+  averageMs: number | null;
+  /** Categorical status based on thresholds. */
+  status: LatencyStatus;
+  /** True while an active probe is in-flight. */
+  measuring: boolean;
+  /** ISO timestamp of the last successful measurement. */
+  lastMeasuredAt: string | null;
+  /** Number of completed measurements in this session. */
+  sampleCount: number;
+  /** Manually trigger an immediate measurement. */
+  measure: () => void;
+}
+
+// ─── Threshold helpers ────────────────────────────────────────────────────────
+
+/**
+ * Classify a raw RTT reading into a status category.
+ * Excellent: ≤ 100 ms  |  Fair: 101–300 ms  |  Poor: > 300 ms
+ */
+export function classifyLatency(ms: number): LatencyStatus {
+  if (ms <= 100) return "excellent";
+  if (ms <= 300) return "fair";
+  return "poor";
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * `useLatency` continuously probes the network round-trip time by firing a
+ * small HEAD request (or using the Resource Timing API entry if available) and
+ * calculates a debounced, smoothed status for the UI.
+ *
+ * @param probeUrl  URL to probe. Defaults to `"/api/ping"`.  Any fast,
+ *                  cacheless endpoint works – the response body is ignored.
+ */
+export function useLatency(probeUrl = "/api/ping"): LatencyState {
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [averageMs, setAverageMs] = useState<number | null>(null);
+  const [status, setStatus] = useState<LatencyStatus>("unknown");
+  const [measuring, setMeasuring] = useState(false);
+  const [lastMeasuredAt, setLastMeasuredAt] = useState<string | null>(null);
+  const [sampleCount, setSampleCount] = useState(0);
+
+  // Rolling window of recent RTT samples
+  const samplesRef = useRef<number[]>([]);
+  // Timer refs
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Track the pending status to debounce it
+  const pendingStatusRef = useRef<LatencyStatus>("unknown");
+
+  // ── Core measurement ──────────────────────────────────────────────────────
+
+  const measure = useCallback(async () => {
+    setMeasuring(true);
+
+    const t0 = performance.now();
+    const cacheKey = `_nc=${t0}`;
+    const url = probeUrl.includes("?")
+      ? `${probeUrl}&${cacheKey}`
+      : `${probeUrl}?${cacheKey}`;
+
+    try {
+      await fetch(url, {
+        method: "HEAD",
+        cache: "no-store",
+        // Suppress auth headers / cookies so the probe is as light as possible
+        credentials: "omit",
+      });
+
+      const t1 = performance.now();
+      let rtt = Math.round(t1 - t0);
+
+      // If the browser supports Resource Timing, prefer that measurement
+      // because it excludes JS overhead and is more accurate.
+      try {
+        const entries = performance.getEntriesByName(url, "resource");
+        const latest = entries[entries.length - 1] as PerformanceResourceTiming | undefined;
+        if (latest && latest.responseEnd > 0 && latest.startTime > 0) {
+          rtt = Math.round(latest.responseEnd - latest.startTime);
+        }
+      } catch {
+        // Resource Timing not supported – use the JS measurement
+      }
+
+      // Update rolling window
+      const samples = [...samplesRef.current, rtt].slice(-WINDOW_SIZE);
+      samplesRef.current = samples;
+
+      const avg = Math.round(
+        samples.reduce((a, b) => a + b, 0) / samples.length
+      );
+
+      setLatencyMs(rtt);
+      setAverageMs(avg);
+      setLastMeasuredAt(new Date().toISOString());
+      setSampleCount((c) => c + 1);
+
+      // Debounce the status so brief jitter doesn't cause UI flicker
+      const newStatus = classifyLatency(avg);
+      pendingStatusRef.current = newStatus;
+
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        setStatus(pendingStatusRef.current);
+      }, STATUS_DEBOUNCE_MS);
+
+      // Before we have MIN_SAMPLES, keep status as "unknown"
+      if (samples.length >= MIN_SAMPLES) {
+        // Status is committed after debounce above
+      } else {
+        setStatus("unknown");
+      }
+    } catch {
+      // Network error – treat as poor (but only if we have no good signal)
+      if (samplesRef.current.length === 0) {
+        setStatus("poor");
+      }
+    } finally {
+      setMeasuring(false);
+    }
+  }, [probeUrl]);
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    // Fire immediately on mount
+    measure();
+
+    intervalRef.current = setInterval(measure, MEASURE_INTERVAL_MS);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [measure]);
+
+  return {
+    latencyMs,
+    averageMs,
+    status,
+    measuring,
+    lastMeasuredAt,
+    sampleCount,
+    measure,
+  };
+}


### PR DESCRIPTION
- Add useLatency hook (hooks/useLatency.ts)
  * Measures RTT every 10s via browser fetch + Performance Resource Timing API
  * Rolling 5-sample moving average with 2s debounce on status changes
  * Classifies latency: Excellent (<=100ms), Fair (101-300ms), Poor (>300ms)
  * SSR-safe, cleans up intervals/timeouts on unmount

- Add LatencyIndicator component (components/network/LatencyIndicator.tsx)
  * Color-coded badge (green/yellow/red) with animated signal bars and pulse dot
  * Hover/click tooltip showing latest RTT, average RTT, sample count, last check
  * Dismissible warning banner (via createPortal) for poor connection state
  * Fully accessible: aria-label, aria-describedby, aria-expanded, role=alert

- Add /api/ping route (app/api/ping/route.ts)
  * Lightweight HEAD + GET endpoint with Cache-Control: no-store headers
  * Used by useLatency as the probe target

- Integrate LatencyIndicator into Navigation.tsx
  * Desktop: renders in the header actions bar (next to dark mode toggle)
  * Mobile: renders in the bottom of the slide-out drawer

Closes #334